### PR TITLE
expose event.source and MouseInputSource::setScreenPosition()

### DIFF
--- a/Source/Lua/JuceClasses/LCore.cpp
+++ b/Source/Lua/JuceClasses/LCore.cpp
@@ -472,6 +472,7 @@ void LMouseEvent::wrapForLua (lua_State *L)
 			.def("getMouseDownScreenY", &MouseEvent::getMouseDownScreenY)
 			.def_readonly("x", &MouseEvent::x)
 			.def_readonly("y", &MouseEvent::y)
+			.def_readonly("source", &MouseEvent::source)
 			.def_readonly("mods", &MouseEvent::mods)
 			.def_readonly("eventTime", &MouseEvent::eventTime)
 			.def_readonly("eventComponent", &MouseEvent::eventComponent)
@@ -484,6 +485,21 @@ void LMouseEvent::wrapForLua (lua_State *L)
 			.def("getMouseDownScreenPosition", &MouseEvent::getMouseDownScreenPosition)
 	];
 }
+/// <summary>
+/// Set mouse XY coords using MouseEvent.source.setScreenPosition(Point(x,y))
+/// </summary>
+/// <param name="L">lua_State</param>
+void LMouseInputSource::wrapForLua(lua_State* L)
+{
+	using namespace luabind;
+
+	module(L)
+		[
+			class_<MouseInputSource>("MouseInputSource")
+				.def("setScreenPosition", &MouseInputSource::setScreenPosition)
+		];
+}
+
 void LRandom::wrapForLua (lua_State *L)
 {
 	using namespace luabind;

--- a/Source/Lua/JuceClasses/LJuce.cpp
+++ b/Source/Lua/JuceClasses/LJuce.cpp
@@ -45,6 +45,7 @@ void CtrlrLuaManager::wrapJuceClasses(lua_State *L)
 	LModifierKeys::wrapForLua(L);
 	LMouseEvent::wrapForLua(L);
 	LMouseCursor::wrapForLua(L);
+	LMouseInputSource::wrapForLua(L);
 	LPath::wrapForLua(L);
 	LPoint::wrapForLua(L);
 	LButton::wrapForLua(L);

--- a/Source/Lua/JuceClasses/LJuce.h
+++ b/Source/Lua/JuceClasses/LJuce.h
@@ -28,6 +28,7 @@
 #include "LModifierKeys.h"
 #include "LMouseCursor.h"
 #include "LMouseEvent.h"
+#include "LMouseInputSource.h"
 #include "LPath.h"
 #include "LPoint.h"
 #include "LPopupMenu.h"

--- a/Source/Lua/JuceClasses/LMouseInputSource.h
+++ b/Source/Lua/JuceClasses/LMouseInputSource.h
@@ -1,0 +1,15 @@
+#ifndef L_MOUSE_INPUT_SOURCE
+#define L_MOUSE_INPUT_SOURCE
+
+extern  "C"
+{
+	#include "lua.h"
+}
+
+class LMouseInputSource
+{
+	public:
+		static void wrapForLua(lua_State* L);
+};
+
+#endif


### PR DESCRIPTION
- Expose the `source' property provided by the MouseEvent listener.
- Then expose MouseInputSource::setScreenPosition()
- this provides access to the mouse cursor and specifically for implementing 'snap-to' capability to help with accessibility in compact UI forms.
- Discussion available here:
  - https://github.com/RomanKubiak/ctrlr/discussions/624 