### PR TITLE
Make workflow compatible with BUILD_TYPE: Debug

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -371,8 +371,6 @@ jobs:
         id: create_archive_unsigned
         shell: bash
         run: |
-          ARTIFACT_DIR="${{ env.ARTIFACTS_PATH }}/Standalone"
-
           # Define the internal folder name for the user's extraction
           INTERNAL_FOLDER_NAME="${{ env.ARTIFACT_NAME }}" # NO "-Signed" suffix
           
@@ -384,8 +382,8 @@ jobs:
           mkdir -p "tmp_linux_archive/$INTERNAL_FOLDER_NAME"
 
           # 2. Copy final assets into the INTERNAL folder
-          cp "${ARTIFACT_DIR}/${{ env.PRODUCT_NAME }}" "tmp_linux_archive/$INTERNAL_FOLDER_NAME/"
-          cp -r "build/CtrlrX_artefacts/Release/VST3/CtrlrX.vst3" "tmp_linux_archive/$INTERNAL_FOLDER_NAME/"
+          cp "${{ env.ARTIFACTS_PATH }}/Standalone/${{ env.PRODUCT_NAME }}" "tmp_linux_archive/$INTERNAL_FOLDER_NAME/"
+          cp -r "${{ env.ARTIFACTS_PATH }}/VST3/CtrlrX.vst3" "tmp_linux_archive/$INTERNAL_FOLDER_NAME/"
 
           # 3. Change into the temporary staging directory (which contains ONE subfolder)
           cd tmp_linux_archive

--- a/Packaging/Windows/installer.iss
+++ b/Packaging/Windows/installer.iss
@@ -2,6 +2,7 @@
 #define ProjectName GetEnv('PROJECT_NAME')
 #define ProductName GetEnv('PRODUCT_NAME')
 #define Publisher GetEnv('COMPANY_NAME')
+#define ArtifactPath GetEnv('ARTIFACTS_PATH')
 #define Year GetDateTimeString("yyyy","","")
 
 ; 'Types': What get displayed during the setup
@@ -35,9 +36,9 @@ Type: filesandordirs; Name: "{commoncf64}\VST3\{#ProductName}Data"
 
 ; MSVC adds a .ilk when building the plugin. Let's not include that.
 [Files]
-Source: "..\..\build\{#ProjectName}_artefacts\Release\VST3\{#ProductName}.vst3\*"; DestDir: "{commoncf64}\VST3\{#ProductName}.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs; Components: vst3
-; Source: "..\..\build\{#ProjectName}_artefacts\Release\CLAP\{#ProductName}.clap"; DestDir: "{commoncf64}\CLAP\"; Flags: ignoreversion; Components: clap
-Source: "..\..\build\{#ProjectName}_artefacts\Release\Standalone\{#ProductName}.exe"; DestDir: "{commonpf64}\{#Publisher}\{#ProductName}"; Flags: ignoreversion; Components: standalone
+Source: "..\..\{#ArtifactPath}\VST3\{#ProductName}.vst3\*"; DestDir: "{commoncf64}\VST3\{#ProductName}.vst3\"; Excludes: *.ilk; Flags: ignoreversion recursesubdirs; Components: vst3
+; Source: "..\..\{#ArtifactPath}\CLAP\{#ProductName}.clap"; DestDir: "{commoncf64}\CLAP\"; Flags: ignoreversion; Components: clap
+Source: "..\..\{#ArtifactPath}\Standalone\{#ProductName}.exe"; DestDir: "{commonpf64}\{#Publisher}\{#ProductName}"; Flags: ignoreversion; Components: standalone
 
 [Icons]
 Name: "{autoprograms}\{#ProductName}"; Filename: "{commonpf64}\{#Publisher}\{#ProductName}\{#ProductName}.exe"; Components: standalone


### PR DESCRIPTION
These are a few changes for if you want to set the BUILD_TYPE to 'Debug' for a branch or fork... Recently tried that so that I could provide a friend with a debug version of the windows build...