### PR TITLE
5.6.35 FIXED JucePlugin_Build_AAX Logic

### DIFF
--- a/Source/Core/CtrlrManager/CtrlrManager.cpp
+++ b/Source/Core/CtrlrManager/CtrlrManager.cpp
@@ -216,17 +216,17 @@ void CtrlrManager::restoreState (const ValueTree &savedTree)
     _DBG("CtrlrManager::restoreState (ValueTree) enter");
 
     // --- Start: Conditional MessageManagerLock for Thread Safety ---
-    #ifndef JucePlugin_Build_AAX
-        // This lock is often necessary for thread safety in other plugin formats (VST/AU/Standalone)
-        // when setStateInformation might involve direct UI updates or MessageManager interactions.
-        // It's REMOVED for AAX builds because AAX calls setStateInformation on a host thread
-        // where acquiring this lock directly can cause deadlocks in newer JUCE versions (v4+).
-        MessageManagerLock mmlock;
-        _DBG("CtrlrManager::restoreState: MessageManagerLock acquired (non-AAX build).");
+    #if JucePlugin_Build_AAX
+		// For AAX builds, the lock is bypassed to prevent deadlock.
+		// Any UI-touching code below MUST be marshalled to the Message Thread via callAsync.
+		_DBG("CtrlrManager::restoreState: MessageManagerLock skipped (AAX build).");
     #else
-        // For AAX builds, the lock is bypassed to prevent deadlock.
-        // Any UI-touching code below MUST be marshalled to the Message Thread via callAsync.
-        _DBG("CtrlrManager::restoreState: MessageManagerLock skipped (AAX build).");
+		// This lock is often necessary for thread safety in other plugin formats (VST/AU/Standalone)
+		// when setStateInformation might involve direct UI updates or MessageManager interactions.
+		// It's REMOVED for AAX builds because AAX calls setStateInformation on a host thread
+		// where acquiring this lock directly can cause deadlocks in newer JUCE versions (v4+).
+		MessageManagerLock mmlock;
+		_DBG("CtrlrManager::restoreState: MessageManagerLock acquired (non-AAX build).");
     #endif
     // --- End: Conditional MessageManagerLock ---
 
@@ -301,7 +301,7 @@ void CtrlrManager::restoreState (const ValueTree &savedTree)
         // --- CRITICAL SECTION FOR AAX UI-RELATED WORK ---
         // If restoreEditorState() (or anything it calls) involves creating/modifying JUCE UI components,
         // it MUST be explicitly marshalled to the JUCE Message Manager thread for AAX builds.
-        #ifdef JucePlugin_Build_AAX
+        #if JucePlugin_Build_AAX
             _DBG("CtrlrManager::restoreState: AAX build - scheduling restoreEditorState on Message Thread.");
             juce::MessageManager::callAsync ([this]() {
                 // This lambda (the code inside {}) will be executed on the JUCE Message Manager thread.

--- a/Source/Core/CtrlrManager/CtrlrManagerInstance.cpp
+++ b/Source/Core/CtrlrManager/CtrlrManagerInstance.cpp
@@ -176,7 +176,7 @@ const String CtrlrManager::getInstanceNameForHost() const
 {
 	if (getInstanceMode() == InstanceSingle || getInstanceMode() == InstanceSingleRestriced)
 	{
-        #ifdef JucePlugin_Build_AAX
+        #if JucePlugin_Build_AAX
             // This code runs ONLY when building for AAX.
             return (ctrlrPlayerInstanceTree.getProperty(Ids::name).toString());
         #else

--- a/Source/Plugin/CtrlrProcessor.cpp
+++ b/Source/Plugin/CtrlrProcessor.cpp
@@ -81,7 +81,12 @@ CtrlrProcessor::~CtrlrProcessor() // Updated v5.6.34. Prevents AAX from crashing
     //    (Confirmed even when property exists and has a default value).
     // 2. Explicitly deleting ctrlrLog (if it were done here) caused crashes on AAX plugin startup scan.
     // The safest approach for AAX is to do minimal work for these components in the destructor.
-    #ifndef JucePlugin_Build_AAX
+    #if JucePlugin_Build_AAX
+        // For JUCE_AAX builds:
+        // We ensure raw pointers are nullified without deletion to avoid crashes during scan/removal.
+        // ScopedPointer will still automatically delete its content (ctrlrManager) when the CtrlrProcessor object is destroyed.
+        ctrlrLog = nullptr;
+    #else
         // For all plugin formats *EXCEPT* AAX:
         // Perform explicit deletion for the raw pointer (ctrlrLog).
         // ScopedPointer (ctrlrManager) will handle its own deletion automatically.
@@ -96,11 +101,6 @@ CtrlrProcessor::~CtrlrProcessor() // Updated v5.6.34. Prevents AAX from crashing
             // It remains here for other macOS builds if it's considered necessary for them. Mainly for panels with timer process handled in the background and delayed saveState() process.
             MessageManager::getInstance()->runDispatchLoopUntil((int)overridesTree.getProperty(Ids::ctrlrShutdownDelay));
         #endif
-    #else
-        // For JUCE_AAX builds:
-        // We ensure raw pointers are nullified without deletion to avoid crashes during scan/removal.
-        // ScopedPointer will still automatically delete its content (ctrlrManager) when the CtrlrProcessor object is destroyed.
-        ctrlrLog = nullptr;
     #endif
 }
 


### PR DESCRIPTION
In some debugging via a provided `./CtrlrX_DBG.log` I noticed it was mentioning using some AAX specific things (while it was the 'StandAlone' version. After looking into those messages, I noticed they were guarded by preprocessor directives. Mostly they were checking if the symbol  `JucePlugin_Build_AAX` was defined, not if it was also set to `1`... In the build directory I noticed compile flags were set like `-DJucePlugin_Build_AAX=0` , which means it's defined, but `0`... So the code would still think it's an AAX build...

Thus, I rewrote some of those preprocessor directives to not look if a symbol is defined, but if it is `1`... 

I'm not sure if that is enough for your desired behavior when compiling an AAX version (you might need some run-time checks, as these `#ifdef`s are in the 'SharedCode' blob, which then gets (statically) linked into the AAX plugin... Something I can't experiment with, but you might :wink: 