### PR TITLE
A github action to create UML diagrams using clang-uml

### DIFF
--- a/.clang-uml
+++ b/.clang-uml
@@ -1,9 +1,19 @@
-# Compile using cmake with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+# Configure using cmake with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON to get compile_commands.json in the build directory.
 # For example:
 #    cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  .
-#    cmake --build build --config Release -j 12
 # With that, the diagrams can be generated with clang-uml.
+#
+# NOTE: The more you restrict the 'glob', the faster diagrams are created. 
+# But you might need to experiment a bit to ensure all elements are found
+
 compilation_database_dir: build
+#debug_mode: true
+# We're not interested in additional code for debugging...
+remove_compile_flags:
+  - -DDEBUG=1
+  - -D_DEBUG=1
+
+
 output_directory: Doc/diagrams
 generate_links:
   #link: "https://github.com/damiensellier/CtrlrX/blob/{{ git.commit }}/{{ element.source.path}}#L{{ element.source.line }}"
@@ -12,80 +22,181 @@ diagrams:
   CtrlrProcessor:
     type: class
     glob:
-      - Source/**/*.h
-      - Source/**/*.cpp
+      include:
+        - Source/**/*.h
+        - Source/Core/**/*.cpp
+        - Source/Plugin/**/*.cpp
+      exclude:
+        - Source/Lua/**/*
+        - Source/Misc/**/*
+        - Source/Resources/**/*
+        - Source/UIComponents/**/*
     include:
       context:
         - match:
             radius: 1
             pattern: CtrlrProcessor
     exclude:
-      paths:
-        - Source/Lua/
-        - Source/Misc/
-        - Source/Resources/
       namespaces:
         - juce
         - std
-      elements:
-        - LeakedObjectDetector
+      element_types:
+        - enum        
       access:
         - private
         - protected
         - public
+
+
   CtrlrMIDIDevice:
     type: class
     glob:
-      - Source/**/*.h
-      - Source/**/*.cpp
+      include:
+        - Source/**/*.h
+        - Source/**/*.cpp
+      exclude:
+        - Source/Lua/**/*
+        - Source/Misc/**/*
+        - Source/Resources/**/*
+        - Source/UIComponents/**/*
     include:
       context:
         - match:
             radius: 1
             pattern: CtrlrMIDIDevice
     exclude:
-      paths:
-        - Source/Lua/
-        - Source/Misc/
-        - Source/Resources/
       namespaces:
         - juce
         - std
-      elements:
-        - LeakedObjectDetector
+      element_types:
+        - enum        
       access:
         - private
         - protected
         - public
+
+
   CtrlrMIDIDeviceManager:
     type: class
     glob:
-      - Source/**/*.h
-      - Source/**/*.cpp
+      include:
+        - Source/**/*.h
+        - Source/**/*.cpp
+      exclude:
+        - Source/Lua/**/*
+        - Source/Misc/**/*
+        - Source/Resources/**/*
+        - Source/UIComponents/**/*
     include:
       context:
         - match:
             radius: 1
             pattern: CtrlrMIDIDeviceManager
     exclude:
-      paths:
-        - Source/Lua/
-        - Source/Misc/
-        - Source/Resources/
       namespaces:
         - juce
         - std
-      elements:
-        - LeakedObjectDetector
+      element_types:
+        - enum        
       access:
         - private
         - protected
         - public
+
+
+  CtrlrPanel:
+    type: class
+    glob:
+      include:
+        - Source/**/*.h
+        - Source/Core/**/*.cpp
+    include:
+      context:
+        - match:
+            radius: 1
+            pattern: CtrlrPanel
+    exclude:
+      paths:
+        - Source/Lua/
+        - Source/Misc/
+        - Source/Resources/
+        - Source/UIComponents/
+      namespaces:
+        - juce
+        - std
+      element_types:
+        - enum        
+      access:
+        - private
+        - protected
+        - public
+
+
+  CtrlrEditor:
+    type: class
+    glob:
+      include:
+        - Source/**/*.h
+        - Source/UIComponents/CtrlrApplicationWindow/**/*.cpp
+      exclude:
+        - Source/Lua/**/*
+        - Source/Misc/**/*
+        - Source/Resources/**/*
+    include:
+      context:
+        - match:
+            radius: 1
+            pattern: CtrlrEditor
+    exclude:
+      namespaces:
+        - juce
+        - std
+      element_types:
+        - enum        
+      access:
+        - private
+        - protected
+        - public
+
+
+  CtrlrPanelEditor:
+    type: class
+    glob:
+      include:
+        - Source/**/*.h
+        - Source/UIComponents/CtrlrPanel/**/*.cpp
+      exclude:
+        - Source/Lua/**/*
+        - Source/Misc/**/*
+        - Source/Resources/**/*
+    include:
+      context:
+        - match:
+            radius: 1
+            pattern: CtrlrPanelEditor
+    exclude:
+      namespaces:
+        - juce
+        - std
+      element_types:
+        - enum        
+      access:
+        - private
+        - protected
+        - public
+
+
   CtrlrProcessor_processBlock:
     type: sequence
     glob:
-      - Source/**/*.h
-      - Source/**/*.cpp
+      include:
+        - Source/**/*.h
+        - Source/**/*.cpp
+      exclude:
+        - Source/Lua/**/*
+        - Source/Misc/**/*
+        - Source/Resources/**/*
+        - Source/UIComponents/**/*
     combine_free_functions_into_file_participants: true
     inline_lambda_messages: false
     generate_message_comments: true
@@ -99,23 +210,26 @@ diagrams:
             radius: 4
             pattern: CtrlrProcessor
     exclude:
-      paths:
-        - Source/Lua/
-        - Source/Misc/
-        - Source/Resources/
       namespaces:
         - juce
         - std
       elements:
-        - LeakedObjectDetector
         - CtrlrLog
     from:
       - function: "CtrlrProcessor::processBlock(juce::AudioSampleBuffer &,juce::MidiBuffer &)"
+
+
   CtrlrPanel_sendMidi_usecases:
     type: sequence
     glob:
-      - Source/**/*.h
-      - Source/**/*.cpp
+      include:
+        - Source/**/*.h
+        - Source/**/*.cpp
+      exclude:
+        - Source/Lua/**/*
+        - Source/Misc/**/*
+        - Source/Resources/**/*
+        - Source/UIComponents/**/*
     combine_free_functions_into_file_participants: true
     inline_lambda_messages: false
     generate_message_comments: true
@@ -129,15 +243,10 @@ diagrams:
             radius: 6
             pattern: CtrlrPanel
     exclude:
-      paths:
-        - Source/Lua/
-        - Source/Misc/
-        - Source/Resources/
       namespaces:
         - juce
         - std
       elements:
-        - LeakedObjectDetector
         - CtrlrLog
     to:
       - function:

--- a/.clang-uml
+++ b/.clang-uml
@@ -1,0 +1,144 @@
+# Compile using cmake with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+# For example:
+#    cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  .
+#    cmake --build build --config Release -j 12
+# With that, the diagrams can be generated with clang-uml.
+compilation_database_dir: build
+output_directory: Doc/diagrams
+generate_links:
+  #link: "https://github.com/damiensellier/CtrlrX/blob/{{ git.commit }}/{{ element.source.path}}#L{{ element.source.line }}"
+  tooltip: "{{ element.source.path}}#L{{ element.source.line }}"
+diagrams:
+  CtrlrProcessor:
+    type: class
+    glob:
+      - Source/**/*.h
+      - Source/**/*.cpp
+    include:
+      context:
+        - match:
+            radius: 1
+            pattern: CtrlrProcessor
+    exclude:
+      paths:
+        - Source/Lua/
+        - Source/Misc/
+        - Source/Resources/
+      namespaces:
+        - juce
+        - std
+      elements:
+        - LeakedObjectDetector
+      access:
+        - private
+        - protected
+        - public
+  CtrlrMIDIDevice:
+    type: class
+    glob:
+      - Source/**/*.h
+      - Source/**/*.cpp
+    include:
+      context:
+        - match:
+            radius: 1
+            pattern: CtrlrMIDIDevice
+    exclude:
+      paths:
+        - Source/Lua/
+        - Source/Misc/
+        - Source/Resources/
+      namespaces:
+        - juce
+        - std
+      elements:
+        - LeakedObjectDetector
+      access:
+        - private
+        - protected
+        - public
+  CtrlrMIDIDeviceManager:
+    type: class
+    glob:
+      - Source/**/*.h
+      - Source/**/*.cpp
+    include:
+      context:
+        - match:
+            radius: 1
+            pattern: CtrlrMIDIDeviceManager
+    exclude:
+      paths:
+        - Source/Lua/
+        - Source/Misc/
+        - Source/Resources/
+      namespaces:
+        - juce
+        - std
+      elements:
+        - LeakedObjectDetector
+      access:
+        - private
+        - protected
+        - public
+  CtrlrProcessor_processBlock:
+    type: sequence
+    glob:
+      - Source/**/*.h
+      - Source/**/*.cpp
+    combine_free_functions_into_file_participants: true
+    inline_lambda_messages: false
+    generate_message_comments: true
+    generate_return_types: true
+    generate_return_values: true
+    generate_condition_statements: true
+    fold_repeated_activities: true
+    include:
+      context:
+        - match:
+            radius: 4
+            pattern: CtrlrProcessor
+    exclude:
+      paths:
+        - Source/Lua/
+        - Source/Misc/
+        - Source/Resources/
+      namespaces:
+        - juce
+        - std
+      elements:
+        - LeakedObjectDetector
+        - CtrlrLog
+    from:
+      - function: "CtrlrProcessor::processBlock(juce::AudioSampleBuffer &,juce::MidiBuffer &)"
+  CtrlrPanel_sendMidi_usecases:
+    type: sequence
+    glob:
+      - Source/**/*.h
+      - Source/**/*.cpp
+    combine_free_functions_into_file_participants: true
+    inline_lambda_messages: false
+    generate_message_comments: true
+    generate_return_types: true
+    generate_return_values: true
+    generate_condition_statements: true
+    fold_repeated_activities: true
+    include:
+      context:
+        - match:
+            radius: 6
+            pattern: CtrlrPanel
+    exclude:
+      paths:
+        - Source/Lua/
+        - Source/Misc/
+        - Source/Resources/
+      namespaces:
+        - juce
+        - std
+      elements:
+        - LeakedObjectDetector
+        - CtrlrLog
+    to:
+      - function:
+          r: "CtrlrPanel::sendMidi\\(.*"

--- a/.github/workflows/clang_uml_diagrams.yml
+++ b/.github/workflows/clang_uml_diagrams.yml
@@ -1,0 +1,116 @@
+name: Make diagrams
+
+on:
+  workflow_dispatch: # lets you run a build from the UI
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+      diagrams_to_generate:
+        type: string
+        description: "Which diagrams to generate? Provide a space-separated list of diagrams found in .clang-uml or 'all')"
+        required: true
+        default: "all"
+
+# When pushing new commits, cancel any running builds on that branch
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  BUILD_TYPE: Release
+  BUILD_DIR: build
+
+defaults:
+  run:
+    shell: bash
+
+# jobs are run in parallel on different machines
+# all steps run in series
+jobs:
+  clang_uml_diagrams:
+    # don't double run on PRs
+    name: Linux
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: "Check if input is given"
+        run: |
+          [[ "${{ inputs.diagrams_to_generate }}" ]] || { echo "diagrams_to_generate input is empty" ; exit 1; }
+      
+      # Use clang on Linux so we don't introduce a 3rd compiler (Windows and macOS use MSVC and Clang)
+      - name: Set up Clang
+        if: runner.os == 'Linux'
+        uses: egor-tensin/setup-clang@v1
+
+      # we need the 'configure' step to pass, thus install the dependencies (and include those for clang-uml)
+      - name: Install JUCE's Linux Deps
+        if: runner.os == 'Linux'
+        # Thanks to McMartin & co https://forum.juce.com/t/list-of-juce-dependencies-under-linux/15121/44
+        run: |
+          sudo add-apt-repository -y ppa:bkryza/clang-uml
+          sudo apt-get update
+          sudo apt install -y libasound2-dev libx11-dev libxinerama-dev libxext-dev libfreetype6-dev libglu1-mesa-dev xvfb ninja-build
+          sudo apt install -y binutils-dev libboost-dev libcurl4-gnutls-dev libgl1-mesa-dev libglapi-mesa libiberty-dev libsframe1 libudev-dev libxcursor-dev libxrandr-dev xorg-dev
+          sudo apt install -y graphviz plantuml clang-uml
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Configure
+        run: >
+          cmake -B ${{ env.BUILD_DIR }}
+          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE}}
+          -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          .
+
+      # We don't need to build in order to get the compile_commands.json, so save resources
+      # - name: Build
+      #   run: cmake --build ${{ env.BUILD_DIR }} --config ${{ env.BUILD_TYPE }}
+
+      # clang uses 1 thread per diagram...
+      - name: "Make PlantUML diagrams"
+        run: |
+          if [ "${{ inputs.diagrams_to_generate }}" = "all" -o -z "${{ inputs.diagrams_to_generate }}" ]
+          then
+            clang-uml --progress --thread-count 0  --generator plantuml 
+          else
+            clang-uml --progress --thread-count 0  --generator plantuml --diagram-name ${{ inputs.diagrams_to_generate }}
+          fi
+
+      - name: "Work-around: Remove double (return) arrows"
+        run: |
+          for F in Doc/diagrams/*.puml
+          do
+              NEW_F=`echo "$F" | sed 's/.puml/.uniq.puml/'`
+              if [[ $F != *'uniq.puml'* ]]
+              then
+                # Use `uniq` to get rid of repeated (return) statements as workaround
+                uniq $F $NEW_F
+              fi
+          done
+      
+      - name: "Convert PlantUML to SVG"
+        run: plantuml -tsvg Doc/diagrams/*.uniq.puml
+                    
+      # -----------------------------------------------------------------
+      # UPLOAD ARTEFACTS
+      # -----------------------------------------------------------------
+
+      - name: Upload diagrams
+        uses: actions/upload-artifact@v4
+        with:
+          name: Diagrams.zip
+          path: |
+            "Doc/diagrams/*.svg"
+            "Doc/diagrams/*.puml"
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session if failed
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ failure() && (github.event_name == 'workflow_dispatch' && inputs.debug_enabled) || (runner.debug) }}
+

--- a/.github/workflows/clang_uml_diagrams.yml
+++ b/.github/workflows/clang_uml_diagrams.yml
@@ -82,6 +82,9 @@ jobs:
             clang-uml --progress --thread-count 0  --generator plantuml --diagram-name ${{ inputs.diagrams_to_generate }}
           fi
 
+          ls -lh Doc/
+          ls -lh Doc/diagrams/
+
       - name: "Work-around: Remove double (return) arrows"
         run: |
           for F in Doc/diagrams/*.puml
@@ -89,13 +92,16 @@ jobs:
               NEW_F=`echo "$F" | sed 's/.puml/.uniq.puml/'`
               if [[ $F != *'uniq.puml'* ]]
               then
+                echo "- $F"
                 # Use `uniq` to get rid of repeated (return) statements as workaround
                 uniq $F $NEW_F
               fi
           done
       
       - name: "Convert PlantUML to SVG"
-        run: plantuml -tsvg Doc/diagrams/*.uniq.puml
+        run: |
+          plantuml -tsvg Doc/diagrams/*.uniq.puml
+          ls -lh Doc/diagrams/
                     
       # -----------------------------------------------------------------
       # UPLOAD ARTEFACTS

--- a/.github/workflows/clang_uml_diagrams.yml
+++ b/.github/workflows/clang_uml_diagrams.yml
@@ -16,7 +16,7 @@ on:
 
 # When pushing new commits, cancel any running builds on that branch
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.ref }}-diagrams
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/clang_uml_diagrams.yml
+++ b/.github/workflows/clang_uml_diagrams.yml
@@ -77,9 +77,9 @@ jobs:
         run: |
           if [ "${{ inputs.diagrams_to_generate }}" = "all" -o -z "${{ inputs.diagrams_to_generate }}" ]
           then
-            clang-uml --progress --thread-count 0  --generator plantuml 
+            clang-uml --thread-count 0  --generator plantuml 
           else
-            clang-uml --progress --thread-count 0  --generator plantuml --diagram-name ${{ inputs.diagrams_to_generate }}
+            clang-uml --thread-count 0  --generator plantuml --diagram-name ${{ inputs.diagrams_to_generate }}
           fi
 
           ls -lh Doc/
@@ -112,8 +112,8 @@ jobs:
         with:
           name: Diagrams.zip
           path: |
-            "Doc/diagrams/*.svg"
-            "Doc/diagrams/*.puml"
+            Doc/diagrams/*.svg
+            Doc/diagrams/*.puml
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session if failed


### PR DESCRIPTION
This PR provides a github action, and a [clang-uml](https://clang-uml.github.io/index.html) configuration file for a few nice diagrams.

- The workflow is a 'manual' workflow. That is, you have to trigger it manually, and you can indicate which diagrams (from the `.clang-uml` file) to generate (as it can be quite slow/resource hungry).

- The `.clang-uml` configuration file can be extended as needed. For now I've added a few class diagrams and a few sequence diagrams that relate to the midi timing  investigation. I'd say: before updating it on github, do test it locally, for example with: `clang-uml --progress --generator plantuml --render_diagrams --plantuml-cmd="/usr/bin/plantuml -tsvg Doc/diagrams/{}.puml"`
