### PR TITLE
Addressing some memory issues identified with Valgrind

### DIFF
--- a/JUCE/modules/juce_audio_basics/midi/juce_MidiMessage.h
+++ b/JUCE/modules/juce_audio_basics/midi/juce_MidiMessage.h
@@ -973,7 +973,7 @@ private:
         uint8 asBytes[sizeof (uint8*)];
     };
 
-    PackedData packedData;
+    PackedData packedData = {};
     double timeStamp = 0;
     int size;
    #endif

--- a/JUCE/modules/juce_core/text/juce_String.cpp
+++ b/JUCE/modules/juce_core/text/juce_String.cpp
@@ -216,7 +216,7 @@ private:
 
     static bool isEmptyString (StringHolder* other)
     {
-        return (other->refCount.get() & 0x30000000) != 0;
+        return static_cast<void*>(other) == &emptyString;
     }
 
     void compileTimeChecks()

--- a/Source/Core/CtrlrManager/CtrlrManager.cpp
+++ b/Source/Core/CtrlrManager/CtrlrManager.cpp
@@ -16,6 +16,7 @@ CtrlrManager::CtrlrManager(CtrlrProcessor *_owner, CtrlrLog &_ctrlrLog)
 		ctrlrMidiDeviceManager(*this),
 		ctrlrDocumentPanel(nullptr),
 		ctrlrManagerVst(nullptr),
+		ctrlrNativeObject(nullptr),
 		audioThumbnailCache(256),
 		ctrlrPlayerInstanceMode(InstanceMulti),
 		ctrlrManagerRestoring(false),

--- a/Source/Core/CtrlrModulator/CtrlrModulatorProcessor.cpp
+++ b/Source/Core/CtrlrModulator/CtrlrModulatorProcessor.cpp
@@ -18,6 +18,7 @@ CtrlrModulatorProcessor::CtrlrModulatorProcessor(CtrlrModulator &_owner)
 		minValue(0),
 		maxValue(127),
 		usingValueMap(false),
+		linkedToGlobal(false),
 		ctrlrMidiMessage(nullptr),
 		ctrlrMidiControllerMessage(nullptr),
 		isMute(false)

--- a/Source/Core/CtrlrPanel/CtrlrPanel.cpp
+++ b/Source/Core/CtrlrPanel/CtrlrPanel.cpp
@@ -18,6 +18,7 @@ CtrlrPanel::CtrlrPanel(CtrlrManager &_owner)
 		: owner(_owner),
 		panelTree(Ids::panel),
 		panelWindowManager(*this),
+		globalVariables({}),
 		ctrlrSysexProcessor(*this),
 		processor(*this),
 		snapshot(*this),
@@ -871,8 +872,8 @@ void CtrlrPanel::removeModulator (CtrlrModulator *modulatorToDelete)
 
 		listeners.call (&CtrlrPanel::Listener::modulatorRemoved, modulatorToDelete);
 
-		ctrlrModulators.removeObject (modulatorToDelete);
 		panelTree.removeChild (modulatorToDelete->getModulatorTree(), 0);
+		ctrlrModulators.removeObject (modulatorToDelete);
 	}
 }
 
@@ -1321,9 +1322,9 @@ void CtrlrPanel::panelReceivedMidi(const MidiBuffer &buffer, const CtrlrMIDIDevi
 {
 	MidiBuffer::Iterator i(buffer);
 	MidiMessage m;
-	int time;
+	int samplePosition;
 
-	while (i.getNextEvent(m,time))
+	while (i.getNextEvent(m, samplePosition))
 	{
 		midiMessageCollector.addMessageToQueue (m);
 	}

--- a/Source/MIDI/CtrlrMidiMessage.cpp
+++ b/Source/MIDI/CtrlrMidiMessage.cpp
@@ -9,7 +9,7 @@
 #include "JuceClasses/LMemoryBlock.h"
 
 CtrlrMidiMessage::CtrlrMidiMessage()
-	:	midiTree(Ids::midi), multiMasterValue(1),
+	:	messageType(None), midiTree(Ids::midi), multiMasterValue(1),
 		multiMasterNumber(1), messagePattern(0,true), restoring(false),
 		initializationResult(Result::ok())
 {
@@ -17,7 +17,7 @@ CtrlrMidiMessage::CtrlrMidiMessage()
 }
 
 CtrlrMidiMessage::CtrlrMidiMessage (const String& hexData)
-	:	midiTree(Ids::midi), multiMasterValue(1),
+	:	messageType(None), midiTree(Ids::midi), multiMasterValue(1),
 		multiMasterNumber(1), messagePattern(0,true),
 		initializationResult(Result::ok())
 {
@@ -58,7 +58,7 @@ CtrlrMidiMessage::CtrlrMidiMessage (const String& hexData)
 }
 
 CtrlrMidiMessage::CtrlrMidiMessage (const MidiMessage& other)
-	:	midiTree(Ids::midi), messagePattern(0,true),
+	:	messageType(None), midiTree(Ids::midi), messagePattern(0,true),
 		initializationResult(Result::ok())
 {
 	initializeEmptyMessage();
@@ -79,7 +79,7 @@ CtrlrMidiMessage::CtrlrMidiMessage (const MidiMessage& other)
 }
 
 CtrlrMidiMessage::CtrlrMidiMessage (MemoryBlock& other)
-	:	midiTree(Ids::midi), messagePattern(0,true), initializationResult(Result::ok())
+	:	messageType(None), midiTree(Ids::midi), messagePattern(0,true), initializationResult(Result::ok())
 {
 	initializeEmptyMessage();
 
@@ -105,7 +105,7 @@ CtrlrMidiMessage::CtrlrMidiMessage (MemoryBlock& other)
 }
 
 CtrlrMidiMessage::CtrlrMidiMessage (const CtrlrLuaObjectWrapper &luaArray)
-	:	midiTree(Ids::midi), multiMasterValue(1),
+	:	messageType(None), midiTree(Ids::midi), multiMasterValue(1),
 		multiMasterNumber(1), messagePattern(0,true),
 		initializationResult(Result::ok())
 {
@@ -141,7 +141,7 @@ CtrlrMidiMessage::CtrlrMidiMessage (const CtrlrLuaObjectWrapper &luaArray)
 }
 
 CtrlrMidiMessage::CtrlrMidiMessage (const CtrlrMidiMessage &other)
-	: midiTree(other.midiTree), initializationResult(Result::ok()),
+	: messageType(None), midiTree(other.midiTree), initializationResult(Result::ok()),
 		messageArray(other.messageArray)
 {
 
@@ -150,7 +150,7 @@ CtrlrMidiMessage::CtrlrMidiMessage (const CtrlrMidiMessage &other)
 }
 
 CtrlrMidiMessage::CtrlrMidiMessage (const Identifier &treeType)
-    : midiTree(treeType), messagePattern(0,true), initializationResult(Result::ok())
+    : messageType(None), midiTree(treeType), messagePattern(0,true), initializationResult(Result::ok())
 {
     initializeEmptyMessage();
 }
@@ -162,7 +162,7 @@ CtrlrMidiMessage::~CtrlrMidiMessage()
 
 void CtrlrMidiMessage::initializeEmptyMessage()
 {
-	setProperty (Ids::midiMessageType, 9);
+	setProperty (Ids::midiMessageType, None);
 	setProperty (Ids::midiMessageChannelOverride, false);
 	setProperty (Ids::midiMessageChannel, 1);
 	setProperty (Ids::midiMessageCtrlrNumber, 1);

--- a/Source/Misc/luabind/luabind/detail/class_registry.hpp
+++ b/Source/Misc/luabind/luabind/detail/class_registry.hpp
@@ -60,7 +60,7 @@ namespace luabind { namespace detail
 
     private:
 
-        std::map<type_id, class_rep*> m_classes;
+        std::map<type_id, class_rep*> m_classes = {};
 
         // this is a lua reference that points to the lua table
         // that is to be used as meta table for all C++ class

--- a/Source/Misc/luabind/luabind/typeid.hpp
+++ b/Source/Misc/luabind/luabind/typeid.hpp
@@ -71,6 +71,10 @@ public:
 
     bool operator<(type_id const& other) const
     {
+        if (!m_id) // there are still situations where "this" is a bad pointer, looks like its getting memory location values in the ASCII range...
+            return false;
+        if (!other.m_id)
+            return true;
 # ifdef LUABIND_SAFE_TYPEID
         return std::strcmp(m_id->name(), other.m_id->name()) < 0;
 # else
@@ -89,6 +93,8 @@ public:
             return demangled_name;
         }
 # endif
+        if (!m_id)
+            throw std::bad_typeid();
         return m_id->name();
     }
 

--- a/Source/UIComponents/CtrlrPanel/CtrlrPanelCanvas.cpp
+++ b/Source/UIComponents/CtrlrPanel/CtrlrPanelCanvas.cpp
@@ -45,7 +45,7 @@ CtrlrPanelCanvas::~CtrlrPanelCanvas()
 		}
 	}
 
-	getOwner().getPanelEditorTree().removeListener (this);
+	getOwner().getPanelEditorTree().removeListener (this); // this is accessing free'd memory. Canvas has to be deleted before valueTree, but not sure where...
     deleteAndZero (ctrlrPanelCanvasResizableBorder);
     setLookAndFeel (nullptr);
 }


### PR DESCRIPTION
In testing/debugging #187  I was using [Valgrind](https://valgrind.org/). Some of the invalid memory access and 'conditional jump on uninitialized value' issues were easily addressed. Some are a bit harder (haven't solved the LUAbind issue in `Source/Misc/luabind/luabind/typeid.hpp` completely)... but this already prevents a few segfaults...