### PR TITLE
Apply proper X11 scaling in Linux

### DIFF
--- a/Source/Core/LinuxDpiScale.cpp
+++ b/Source/Core/LinuxDpiScale.cpp
@@ -1,0 +1,72 @@
+#include "LinuxDpiScale.h"
+
+#if defined(__linux__)
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <X11/Xlib.h>
+#include <X11/Xresource.h>
+
+static double get_scale_from_env(const char* name)
+{
+    const char* value = std::getenv(name);
+    if (value == nullptr || value[0] == '\0')
+        return 0.0;
+
+    char* end = nullptr;
+    const double scale = std::strtod(value, &end);
+    if (end == value || !std::isfinite(scale))
+        return 0.0;
+
+    return scale < 1.0 ? 1.0 : scale;
+}
+
+double ctrlrx_get_linux_scale_factor()
+{
+    const double ctrlrxScale = get_scale_from_env("CTRLRX_SCALE_FACTOR");
+    if (ctrlrxScale > 0.0)
+        return ctrlrxScale;
+
+    Display* display = XOpenDisplay(nullptr);
+    if (display == nullptr)
+        return 1.0;
+
+    XrmInitialize();
+
+    double dpi = 96.0;
+    char* rms = XResourceManagerString(display);
+    if (rms != nullptr)
+    {
+        XrmDatabase db = XrmGetStringDatabase(rms);
+        if (db != nullptr)
+        {
+            char* type = nullptr;
+            XrmValue value = { 0 };
+
+            if (XrmGetResource(db, "Xft.dpi", "Xft.Dpi", &type, &value)
+                && type != nullptr
+                && std::strcmp(type, "String") == 0
+                && value.addr != nullptr)
+            {
+                char* end = nullptr;
+                const double xftDpi = std::strtod(value.addr, &end);
+                if (xftDpi > 0.0 && std::isfinite(xftDpi))
+                    dpi = xftDpi;
+            }
+
+            XrmDestroyDatabase(db);
+        }
+    }
+
+    XCloseDisplay(display);
+    return dpi / 96.0;
+}
+
+#else
+
+double ctrlrx_get_linux_scale_factor()
+{
+    return 1.0;
+}
+
+#endif

--- a/Source/Core/LinuxDpiScale.h
+++ b/Source/Core/LinuxDpiScale.h
@@ -1,0 +1,2 @@
+#pragma once
+double ctrlrx_get_linux_scale_factor();

--- a/Source/Core/StandaloneWrapper/CtrlrStandaloneApplication.cpp
+++ b/Source/Core/StandaloneWrapper/CtrlrStandaloneApplication.cpp
@@ -2,6 +2,11 @@
 #include "CtrlrMacros.h"
 #include "CtrlrLog.h"
 #include "CtrlrStandaloneWindow.h"
+#include "LinuxDpiScale.h"
+
+#if JUCE_LINUX
+ #include <cmath>
+#endif
 
 class CtrlrApplication : public JUCEApplication
 {
@@ -68,6 +73,13 @@ class CtrlrApplication : public JUCEApplication
                 {
 					Logger::writeToLog("CTRLR:initialise params \""+commandLineParameters+"\"");
 
+#if JUCE_LINUX
+					const double linuxScale = ctrlrx_get_linux_scale_factor();
+					if (std::abs(linuxScale - 1.0) > 0.001)
+						Desktop::getInstance().setGlobalScaleFactor((float)linuxScale);
+
+					Logger::writeToLog("CTRLR:linux scale factor \"" + String(linuxScale, 3) + "\"");
+#endif
 
 					{
 						bool setcrashhandler = true;


### PR DESCRIPTION
This uses xlib / xresource to obtain the current DPI when running on Linux; in Linux, X11 is always used, even on Wayland w/ XWayland (JUCE limitation).

This gets the DPI and calculates the scale factor from it. The code is inspired by DISTRHO DPF's code, [issue](https://github.com/DISTRHO/DPF/issues/308), [code in current version](https://github.com/DISTRHO/DPF/blob/4238e1c7f0351bbe488d79f0899c540543ac7583/distrho/src/DistrhoUI.cpp#L134-L163). Didn't want to do anything fancier, this works just fine.

Solves #219.