### PR TITLE
5.6.36 FIX Prevent static modifiers from beeing updated by host

### DIFF
--- a/Source/Core/CtrlrModulator/CtrlrModulatorProcessor.cpp
+++ b/Source/Core/CtrlrModulator/CtrlrModulatorProcessor.cpp
@@ -341,7 +341,7 @@ void CtrlrModulatorProcessor::setValueFromMIDI(CtrlrMidiMessage &m, const CtrlrM
 
 void CtrlrModulatorProcessor::setParameterNotifyingHost() // CtrlrX->VST Host
 {
-	if (owner.getVstIndex() >= 0 && owner.isExportedToVst())
+	if (owner.getVstIndex() >= 0 && owner.isExportedToVst() && !owner.isStatic())
 	{
 		getProcessor()->setParameterNotifyingHost (owner.getVstIndex(), normalizeValue (currentValue.value, minValue, maxValue));
 	}


### PR DESCRIPTION
See:
https://github.com/damiensellier/CtrlrX/issues/259#issuecomment-4510606620

This prevents the update of static modifiers from the host or other panels.