### PR TITLE
5.6.36 FIXED Memory fixes

### DIFF
--- a/Source/Core/CtrlrFontManager.cpp
+++ b/Source/Core/CtrlrFontManager.cpp
@@ -94,6 +94,7 @@ void CtrlrFontManager::fillCombo (ComboBox &comboToFill, const bool showOsFonts,
 {
 	comboToFill.clear();
 	int i = 0;
+	allFontCount = 0;
 
 	if (showJuceFonts)
 	{

--- a/Source/Core/CtrlrFontManager.h
+++ b/Source/Core/CtrlrFontManager.h
@@ -57,7 +57,7 @@ class CtrlrFontManager
 		StringArray osTypefaceNames;
 		StringArray osTypefaceStyles;
         Font defaultFont;
-		int64 allFontCount;
+		int64 allFontCount = 0;
 };
 
 #endif

--- a/Source/Lua/CtrlrLuaManager.cpp
+++ b/Source/Lua/CtrlrLuaManager.cpp
@@ -249,7 +249,11 @@ void CtrlrLuaManager::assignDefaultObjects(lua_State* L)
 	luabind::globals(L)["atc"] = &owner.getCtrlrManagerOwner().getAudioThumbnailCache();
 	luabind::globals(L)["converter"] = audioConverter;
 	luabind::globals(L)["resources"] = &owner.getResourceManager();
-	luabind::globals(L)["native"] = CtrlrNative::getNativeObject(owner.getCtrlrManagerOwner());
+	// Reuse the manager-owned native object (a non-owning pointer, like the globals around it).
+	// Do NOT call the static getNativeObject() factory here: it allocates a fresh CtrlrNative on
+	// every panel load that nothing frees. The owned instance is set unconditionally in
+	// CtrlrManager::initEmbeddedInstance() before any panel's Lua state is assigned.
+	luabind::globals(L)["native"] = &owner.getCtrlrManagerOwner().getNativeObject();
 	luabind::globals(L)["devices"] = &owner.getCtrlrManagerOwner().getCtrlrMIDIDeviceManager();
 }
 

--- a/Source/Lua/CtrlrLuaObjectWrapper.cpp
+++ b/Source/Lua/CtrlrLuaObjectWrapper.cpp
@@ -4,12 +4,30 @@
 
 CtrlrLuaObjectWrapper::CtrlrLuaObjectWrapper()
 {
-	new luabind::object();
+	o = new luabind::object();
 }
 
 CtrlrLuaObjectWrapper::CtrlrLuaObjectWrapper(luabind::object const& other)
 {
 	o = new luabind::object(other);
+}
+
+CtrlrLuaObjectWrapper::CtrlrLuaObjectWrapper(const CtrlrLuaObjectWrapper& other)
+{
+	o = new luabind::object(*other.o);
+}
+
+CtrlrLuaObjectWrapper& CtrlrLuaObjectWrapper::operator= (const CtrlrLuaObjectWrapper& other)
+{
+	if (this != &other)
+		*o = *other.o;
+
+	return *this;
+}
+
+CtrlrLuaObjectWrapper::~CtrlrLuaObjectWrapper()
+{
+	delete o;
 }
 
 CtrlrLuaObjectWrapper::operator luabind::object &()

--- a/Source/Lua/CtrlrLuaObjectWrapper.h
+++ b/Source/Lua/CtrlrLuaObjectWrapper.h
@@ -8,6 +8,9 @@ class CtrlrLuaObjectWrapper
 	public:
 		CtrlrLuaObjectWrapper();
     CtrlrLuaObjectWrapper(luabind::object const& other);
+		CtrlrLuaObjectWrapper(const CtrlrLuaObjectWrapper& other);
+		CtrlrLuaObjectWrapper& operator= (const CtrlrLuaObjectWrapper& other);
+		~CtrlrLuaObjectWrapper();
 		operator luabind::object &();
 		operator luabind::object();
 		const luabind::object &getLuabindObject() const;

--- a/Source/Lua/JuceClasses/LCore.cpp
+++ b/Source/Lua/JuceClasses/LCore.cpp
@@ -286,10 +286,8 @@ void LGlobalFunctions::wrapForLua (lua_State *L)
 		class_<CtrlrNative>("CtrlrNative")
             .def("sendKeyPressEvent", (const Result (CtrlrNative::*) (const KeyPress &, const String &)) &CtrlrNative::sendKeyPressEvent)
 			.def("sendKeyPressEvent", (const Result (CtrlrNative::*) (const KeyPress &)) &CtrlrNative::sendKeyPressEvent)
-            .scope
-            [
-                def("getNativeObject", &CtrlrNative::getNativeObject)
-            ]
+            // The static getNativeObject() factory binding was removed: it allocated a fresh
+            // CtrlrNative on every call that nothing freed. Scripts use the `native` global instead.
 		,
 		def("jmax", (double (*) (const double, const double))&juce::jmax<double>),
 		def("jmax", (double (*) (const double, const double, const double))&juce::jmax<double>),

--- a/Source/Native/CtrlrNative.h
+++ b/Source/Native/CtrlrNative.h
@@ -23,6 +23,7 @@ class CtrlrManager;
 class CtrlrNative
 {
 	public:
+		virtual ~CtrlrNative() = default;
 		static CtrlrNative *getNativeObject(CtrlrManager &owner);
 		virtual const Result exportWithDefaultPanel (CtrlrPanel *,
                                                         const bool,

--- a/Source/UIComponents/CtrlrComponents/Groups/CtrlrGroup.cpp
+++ b/Source/UIComponents/CtrlrComponents/Groups/CtrlrGroup.cpp
@@ -320,6 +320,13 @@ void CtrlrGroup::setOwned (CtrlrComponent *componentToOwn, const int subIndexInG
     if (componentToOwn == nullptr) // Updated v5.6.36
         return;
 
+    // A group must not adopt itself or any ancestor of its own content. Corrupt/cyclic panel data
+    // (componentGroupName forming a loop: a group grouped into itself, or two groups grouped into
+    // each other) would otherwise add an ancestor under content -> a parent/child cycle in the
+    // component tree -> infinite Component::internalHierarchyChanged recursion -> stack overflow.
+    if (componentToOwn == (CtrlrComponent*) this || componentToOwn->isParentOf (&content))
+        return;
+
     if (shouldOwnThisComponent)
     {
 		content.addAndMakeVisible (componentToOwn);

--- a/Source/UIComponents/CtrlrPanel/CtrlrPanelCanvas.cpp
+++ b/Source/UIComponents/CtrlrPanel/CtrlrPanelCanvas.cpp
@@ -45,7 +45,9 @@ CtrlrPanelCanvas::~CtrlrPanelCanvas()
 		}
 	}
 
-	getOwner().getPanelEditorTree().removeListener (this); // this is accessing free'd memory. Canvas has to be deleted before valueTree, but not sure where...
+	// Safe: panelEditorTree is declared ahead of the component ScopedPointers in CtrlrPanelEditor,
+	// so it outlives this canvas and is still alive here during ~CtrlrPanelEditor.
+	getOwner().getPanelEditorTree().removeListener (this);
     deleteAndZero (ctrlrPanelCanvasResizableBorder);
     setLookAndFeel (nullptr);
 }

--- a/Source/UIComponents/CtrlrPanel/CtrlrPanelCanvas.h
+++ b/Source/UIComponents/CtrlrPanel/CtrlrPanelCanvas.h
@@ -234,7 +234,7 @@ private:
 		luaPanelFileDragDropHandlerCbk,
 		luaPanelFileDragEnterHandlerCbk,
 		luaPanelFileDragExitHandlerCbk;
-	int64 lastRMBMouseEventTime, lastLMBMouseEventTime;
+	int64 lastRMBMouseEventTime = 0, lastLMBMouseEventTime = 0;
 	OwnedArray <CtrlrPanelCanvasLayer> layers;
     ResizableBorderComponent* ctrlrPanelCanvasResizableBorder;
     CtrlrPanelCanvas (const CtrlrPanelCanvas&);

--- a/Source/UIComponents/CtrlrPanel/CtrlrPanelEditor.h
+++ b/Source/UIComponents/CtrlrPanel/CtrlrPanelEditor.h
@@ -115,7 +115,12 @@ class CtrlrPanelEditor  :	public Component,
 	private:
         // Declare the LookAndFeel pointer first to ensure it is destroyed last
         std::unique_ptr<juce::LookAndFeel> lookAndFeel;
-    
+
+        // Declared before the component ScopedPointers below so it is destroyed *after* them:
+        // the viewport -> magnifier -> canvas chain unregisters itself as a listener on this tree
+        // in ~CtrlrPanelCanvas, so the tree must still be alive when those components are destroyed.
+        ValueTree panelEditorTree;
+
         // Old way
         // CtrlrPanelProperties* ctrlrPanelProperties;
         // StretchableLayoutResizerBar* spacerComponent;
@@ -136,8 +141,7 @@ class CtrlrPanelEditor  :	public Component,
 		StretchableLayoutManager layoutManager;
 		bool lastEditMode, currentRestoreState;
 		CtrlrManager &ctrlrManager;
-		ValueTree panelEditorTree;
-    
+
         // The macro JUCE_DECLARE_WEAK_REFERENCEABLE(CtrlrPanelEditor)
         // already handles the weak reference master.
         // The following lines are redundant and should be removed from your code.

--- a/Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.cpp
+++ b/Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.cpp
@@ -16,10 +16,13 @@ CtrlrPropertyComponent::CtrlrPropertyComponent (const Identifier &_propertyName,
 		identifierDefinition(_identifierDefinition),
 		propertyName(_propertyName),
 		propertyElement(_propertyElement),
-		panel(_panel),
-		possibleChoices(_possibleChoices),
-		possibleValues(_possibleValues)
+		panel(_panel)
 {
+	if (_possibleChoices != nullptr)
+		possibleChoices = *_possibleChoices;
+
+	if (_possibleValues != nullptr)
+		possibleValues = *_possibleValues;
 
 //    if (propertyName == Ids::midiMessageCtrlrValue) // ADDED v5.6.35. For Multi MIDI Message. Thanks to @dnaldoog
 //    {
@@ -141,8 +144,8 @@ Component *CtrlrPropertyComponent::getPropertyComponent()
     _DBG("Property Name: " + propertyName.toString() + " | XML Type: " + identifierDefinition.getProperty("type").toString() + " | Mapped Type: " + String(propertyType));
     if (propertyName == Ids::componentLayerUid)
     {
-        possibleChoices = new StringArray();
-        possibleValues = new Array<var>();
+        possibleChoices.clear();
+        possibleValues.clear();
 
         if (panel != nullptr && panel->getCanvas() != nullptr)
         {
@@ -152,8 +155,8 @@ Component *CtrlrPropertyComponent::getPropertyComponent()
                 CtrlrPanelCanvasLayer* layer = canvas->getLayerFromArray(i);
                 if (layer != nullptr)
                 {
-                    possibleChoices->add(layer->getProperty(Ids::uiPanelCanvasLayerName).toString());
-                    possibleValues->add(layer->getProperty(Ids::uiPanelCanvasLayerUid).toString());
+                    possibleChoices.add(layer->getProperty(Ids::uiPanelCanvasLayerName).toString());
+                    possibleValues.add(layer->getProperty(Ids::uiPanelCanvasLayerUid).toString());
                 }
             }
         }
@@ -259,12 +262,12 @@ Component *CtrlrPropertyComponent::getPropertyComponent()
 		case CtrlrIDManager::VarNumeric:
             // preferredHeight = 36;
             preferredHeight = roundDoubleToInt(propertyLineheightBaseValue * 1.0); // Updated v5.6.33.
-			return (new CtrlrChoicePropertyComponent(valueToControl, possibleChoices, possibleValues, true));
+			return (new CtrlrChoicePropertyComponent(valueToControl, &possibleChoices, &possibleValues, true));
             
 		case CtrlrIDManager::VarText:
             // preferredHeight = 36;
             preferredHeight = roundDoubleToInt(propertyLineheightBaseValue * 1.0); // Updated v5.6.33.
-			return (new CtrlrChoicePropertyComponent(valueToControl, possibleChoices, possibleValues, false));
+			return (new CtrlrChoicePropertyComponent(valueToControl, &possibleChoices, &possibleValues, false));
             
 		case CtrlrIDManager::FileProperty:
             // preferredHeight = 36;

--- a/Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.h
+++ b/Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.h
@@ -60,8 +60,8 @@ class CtrlrPropertyComponent  : public PropertyComponent, public ValueTree::List
 		Font currentFont;
 		CtrlrIDManager::PropertyType propertyType;
 		CtrlrPanel *panel;
-		StringArray *possibleChoices;
-		Array<var>  *possibleValues;
+		StringArray possibleChoices;
+		Array<var>  possibleValues;
 		URL url;
 		String urlString;
 };

--- a/Source/UIComponents/CtrlrWindowManagers/CtrlrChildWindow.cpp
+++ b/Source/UIComponents/CtrlrWindowManagers/CtrlrChildWindow.cpp
@@ -16,6 +16,11 @@ public:
         startTimer(10); // 10ms interval
     }
 
+    ~LinuxFadeInWindow() override
+    {
+        stopTimer();
+    }
+
     void timerCallback() override
     {
         if (!comp) { stopTimer(); return; }
@@ -61,7 +66,7 @@ CtrlrChildWindow::CtrlrChildWindow(CtrlrWindowManager &_owner)
     centreWithSize(getWidth(), getHeight());
 
     // fade-in
-    new LinuxFadeInWindow(this);
+    fadeInTimer.reset(new LinuxFadeInWindow(this));
 
 #else
     setContentOwned(containerComponent, true);

--- a/Source/UIComponents/CtrlrWindowManagers/CtrlrChildWindow.h
+++ b/Source/UIComponents/CtrlrWindowManagers/CtrlrChildWindow.h
@@ -9,6 +9,9 @@ class CtrlrChildWindowContent;
 class CtrlrLookAndFeel;
 class CtrlrChildWindow;
 class CtrlrManager;
+#if JUCE_LINUX
+class LinuxFadeInWindow;
+#endif
 class CtrlrWindowManager
 {
 	public:
@@ -41,4 +44,7 @@ class CtrlrChildWindow  : public DocumentWindow, public KeyListener
 		CtrlrChildWindowContent *contentComponent;
 		CtrlrWindowManager &owner;
 		TooltipWindow window;
+#if JUCE_LINUX
+		std::unique_ptr<LinuxFadeInWindow> fadeInTimer;
+#endif
 };


### PR DESCRIPTION
running CtrlrX with valgrind while opening a panel etc, and parsing the output, there were a few more memory issues to solve. This PR addresses them.
This also uncovered a recursive 'setOwned' in `Source/UIComponents/CtrlrComponents/Groups/CtrlrGroup.cpp` that is now prevented.

I've also compared it to the branch of @dnaldoog  . Mostly no conflicts except maybe some space vs tab issue*.
But there is one set of files to watch out for:
- Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.cpp  <-- this overlaps with the branch from @dnaldoog ..., depending on who merges first: please follow the new pattern of not creating a `new StringArray`/`new Array` for `possibleChoices` and `possibleValues`, but call .clear(); on both of them to prevent memory leaks. (Towards the future, we best use std::unique_ptr or std::shared_ptr instead of 'new' directly, to prevent memory leaks.)
- Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.h changed from pointer to normal object



*) with respect to the spaces vs tabs issue: You guys could consider using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) with some  [style](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) of your choice. Most editors/IDEs have some form of clang-format integration. Having it format for you automatically on file save or paste is ideal to keep it consistent.