### PR TITLE
5.6.36 maintenance 202607 updt dnaldoog addons

### DIFF
--- a/Source/Core/CtrlrManager/CtrlrManager.cpp
+++ b/Source/Core/CtrlrManager/CtrlrManager.cpp
@@ -37,6 +37,8 @@ CtrlrManager::CtrlrManager(CtrlrProcessor *_owner, CtrlrLog &_ctrlrLog)
 
 CtrlrManager::~CtrlrManager()
 {
+    shuttingDown = true; // Added v5.6.36. Thanks to @dnaldoog. Freeze tree updates instantly
+    _DBG("!!! DTOR for CtrlrManager");
     commandManager.removeListener (this);
     ctrlrDocumentPanel->closeAllDocuments(false);
     ctrlrPanels.clear();

--- a/Source/Core/CtrlrManager/CtrlrManager.h
+++ b/Source/Core/CtrlrManager/CtrlrManager.h
@@ -247,6 +247,7 @@ class CtrlrManager :    public ValueTree::Listener,
 		void setProperty (const Identifier& name, const var &newValue)											{ managerTree.setProperty (name, newValue, 0); }
 		const var &getProperty (const Identifier& name) const													{ return managerTree.getProperty (name); }
 		const var getProperty (const Identifier& name, const var &defaultReturnValue) const						{ return managerTree.getProperty (name, defaultReturnValue); }
+		bool isShuttingDown() const noexcept																	{ return shuttingDown; } // Added v5.6.36. Thanks to @dnaldoog
 		CtrlrLog &getCtrlrLog()																					{ return (ctrlrLog); }
 		void removePanel (CtrlrPanelEditor *editor);
 		CtrlrPanel *getActivePanel();
@@ -342,6 +343,7 @@ class CtrlrManager :    public ValueTree::Listener,
 
 	private:
 
+		bool shuttingDown = false; // Added v5.6.36. Thanks to @dnaldoog
 		void setEmbeddedDefaults();
 		Result addInstancePanel();
 		void restoreInstanceState(const ValueTree &instanceState);

--- a/Source/Core/CtrlrManager/CtrlrManager.h
+++ b/Source/Core/CtrlrManager/CtrlrManager.h
@@ -247,9 +247,7 @@ class CtrlrManager :    public ValueTree::Listener,
 		void setProperty (const Identifier& name, const var &newValue)											{ managerTree.setProperty (name, newValue, 0); }
 		const var &getProperty (const Identifier& name) const													{ return managerTree.getProperty (name); }
 		const var getProperty (const Identifier& name, const var &defaultReturnValue) const						{ return managerTree.getProperty (name, defaultReturnValue); }
-		bool isShuttingDown() const noexcept {
-			return shuttingDown;
-		} // Added v5.6.36. Thanks to @dnaldoog
+		bool isShuttingDown() const noexcept																	{ return shuttingDown; } // Added v5.6.36. Thanks to @dnaldoog
 		CtrlrLog &getCtrlrLog()																					{ return (ctrlrLog); }
 		void removePanel (CtrlrPanelEditor *editor);
 		CtrlrPanel *getActivePanel();

--- a/Source/Core/CtrlrManager/CtrlrManager.h
+++ b/Source/Core/CtrlrManager/CtrlrManager.h
@@ -247,7 +247,9 @@ class CtrlrManager :    public ValueTree::Listener,
 		void setProperty (const Identifier& name, const var &newValue)											{ managerTree.setProperty (name, newValue, 0); }
 		const var &getProperty (const Identifier& name) const													{ return managerTree.getProperty (name); }
 		const var getProperty (const Identifier& name, const var &defaultReturnValue) const						{ return managerTree.getProperty (name, defaultReturnValue); }
-		bool isShuttingDown() const noexcept																	{ return shuttingDown; } // Added v5.6.36. Thanks to @dnaldoog
+		bool isShuttingDown() const noexcept {
+			return shuttingDown;
+		} // Added v5.6.36. Thanks to @dnaldoog
 		CtrlrLog &getCtrlrLog()																					{ return (ctrlrLog); }
 		void removePanel (CtrlrPanelEditor *editor);
 		CtrlrPanel *getActivePanel();

--- a/Source/Core/CtrlrPanel/CtrlrPanel.cpp
+++ b/Source/Core/CtrlrPanel/CtrlrPanel.cpp
@@ -242,7 +242,9 @@ CtrlrPanel::~CtrlrPanel()
 
 	ctrlrModulators.clear();
 
-	owner.getManagerTree().removeChild (panelTree, 0);
+	if (!owner.isShuttingDown()) {
+		owner.getManagerTree().removeChild(panelTree, 0);
+	}
 }
 
 void CtrlrPanel::setRestoreState(const bool _restoreStateStatus)

--- a/Source/Core/CtrlrRevision.h
+++ b/Source/Core/CtrlrRevision.h
@@ -6,7 +6,7 @@ static const char *ctrlrRevision          = JucePlugin_VersionString;
 #ifdef JUCE_MAC
 // macOS build: Use build script-generated timestamp
 #ifndef BUILD_TIMESTAMP
-#define BUILD_TIMESTAMP "2026-07-20 23:06:08"
+#define BUILD_TIMESTAMP "2026-07-21 13:13:05"
 #endif
 static const char *ctrlrRevisionDate      = BUILD_TIMESTAMP; // Updated v5.6.32. FIX for Xcode not updating build time properly and keeping the first build timestamp as ref
 

--- a/Source/Core/CtrlrSysexProcessor.cpp
+++ b/Source/Core/CtrlrSysexProcessor.cpp
@@ -536,7 +536,6 @@ void CtrlrSysexProcessor::checksumTechnics(const CtrlrSysexToken token, MidiMess
 
 void CtrlrSysexProcessor::checksumRolandJp8080(const CtrlrSysexToken token, MidiMessage &m) // Update v5.6.34. Thanks to @dnaldoog
 {
-	_DBG("I am Roland");
 	const int startByte = token.getPosition() - token.getAdditionalData();
 	uint8 chTotal		= 0;
 	uint8 *ptr	= (uint8 *)m.getRawData();

--- a/Source/Core/StandaloneWrapper/CtrlrStandaloneWindow.cpp
+++ b/Source/Core/StandaloneWrapper/CtrlrStandaloneWindow.cpp
@@ -191,6 +191,10 @@ void CtrlrStandaloneWindow::changeListenerCallback(ChangeBroadcaster* source)
 void CtrlrStandaloneWindow::saveStateNow()
 {
     _DBG("CtrlrStandaloneWindow::saveStateNow");
+    		// If the manager is already in the middle of running its destructor,
+		// instantly break out so we don't spin up phantom UI updates or leaks!
+    	if (ctrlrProcessor != nullptr && ctrlrProcessor->getManager().isShuttingDown())
+        return;
 
     if (ctrlrProcessor != nullptr && appProperties != nullptr)
     {

--- a/Source/Lua/CtrlrLuaObjectWrapper.h
+++ b/Source/Lua/CtrlrLuaObjectWrapper.h
@@ -7,7 +7,7 @@ class CtrlrLuaObjectWrapper
 {
 	public:
 		CtrlrLuaObjectWrapper();
-    CtrlrLuaObjectWrapper(luabind::object const& other);
+		CtrlrLuaObjectWrapper(luabind::object const& other);
 		CtrlrLuaObjectWrapper(const CtrlrLuaObjectWrapper& other);
 		CtrlrLuaObjectWrapper& operator= (const CtrlrLuaObjectWrapper& other);
 		~CtrlrLuaObjectWrapper();


### PR DESCRIPTION
## Summary
This PR fixes a critical startup/panel-loading crash (`juce_NormalisableRange.h:242` assertion failure) that occurs when legacy or complex panels (like the Roland JD-990) initialize sliders with flat (`min == max`), inverted, or empty ranges. 

## The Problem
Modern versions of JUCE (JUCE 6+) strictly assert that a range's maximum must be greater than its minimum (`end > start`). Legacy Ctrlr code frequently passed raw XML property values or uninitialized value map bounds (resulting in `0` to `0` or inverted limits like `127` to `0`) directly into `juce::Slider::setRange()`, triggering immediate crashes. 

Furthermore, previous attempts to fix this were applied inconsistently across the codebase, leaving certain slider types unpatched.

## The Solution
1. **Centralized Math Sanitization:** Created a static utility helper `CtrlrComponent::applySafeSliderRange` that ensures `min <= max` mathematically and adds a tiny safety pad (`0.0001`) if they are equal to satisfy JUCE's invariants.
2. **Standardized Across Slider Components:** Refactored all slider variants to route their range changes through this helper, ensuring robust protection without modifying original modulator properties:
   * `CtrlrSlider`
   * `CtrlrImageSlider`
   * `CtrlrFixedSlider` (fixes `sliderContentChanged()` crash)
   * `CtrlrFixedImageSlider` (fixes `sliderContentChanged()` crash)

## Verification
* Successfully tested loading complex panels like the JD-990.
* Verified that inverted sliders still retain their correct mapping behavior while keeping JUCE's internal range assertions silent.

## Changed projucer file for LuaJIT
* I had trouble getting luajit to compile but finally got it working

## Added a guard for functions (CtrlrSlider etc)::resetLookAndFeelOverrides() 
```c++
	if (!isLookAndFeelOverrideEnabled()) {
		_DBG("RESET_LF: Aborting - System is shutting down or restoring state.");
		return;
	}
```

This seems to prevent a lot of exit leaks, but is a work in progress as it seems sometimes leaks are happening somewhere, especially with LNF teardown.