### PR TITLE
Re-apply memory leak fix and make tests forward compatible with JUCE 8

### DIFF
--- a/Source/UIComponents/CtrlrLua/MethodEditor/CtrlrLuaMethodCodeEditor.cpp
+++ b/Source/UIComponents/CtrlrLua/MethodEditor/CtrlrLuaMethodCodeEditor.cpp
@@ -1864,7 +1864,7 @@ void CtrlrLuaMethodCodeEditor::toggleLineComment() // Updated v5.6.34
 
     // Check if we should comment or uncomment
     bool allLinesCommented = true;
-    for (int lineNum = startLine; lineNum <= endLine; ++lineNum)
+    for (int lineNum = startLine; lineNum < endLine; ++lineNum) // Updated v5.6.36. Thanks to @dnaldoog. Was <= . Prevents crash. REF: issue #314
     {
         String line = document.getLine(lineNum);
         if (line.trimStart().isEmpty() || !line.trimStart().startsWith("--"))
@@ -1875,7 +1875,7 @@ void CtrlrLuaMethodCodeEditor::toggleLineComment() // Updated v5.6.34
     }
 
     // Comment or uncomment
-    for (int lineNum = startLine; lineNum <= endLine; ++lineNum)
+    for (int lineNum = startLine; lineNum < endLine; ++lineNum) // Updated v5.6.36. Thanks to @dnaldoog. Prevents crash. REF: issue #314
     {
         CodeDocument::Position lineStart(document, lineNum, 0);
         String line = document.getLine(lineNum);

--- a/Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.cpp
+++ b/Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.cpp
@@ -6,37 +6,34 @@
 #include <juce_gui_basics/juce_gui_basics.h>  // ADDED v5.6.35. For Multi MIDI Message. Thanks to @dnaldoog
 using namespace juce; // ADDED v5.6.35. For Multi MIDI Message. Thanks to @dnaldoog
 
-CtrlrPropertyComponent::CtrlrPropertyComponent (const Identifier &_propertyName,
-								const ValueTree &_propertyElement,
-								const ValueTree &_identifierDefinition,
-								CtrlrPanel *_panel,
-								StringArray *_possibleChoices,
-								Array<var>  *_possibleValues)
-	:	PropertyComponent (_propertyName.toString()),
-		identifierDefinition(_identifierDefinition),
-		propertyName(_propertyName),
-		propertyElement(_propertyElement),
-		panel(_panel),
-		possibleChoices(_possibleChoices),
-		possibleValues(_possibleValues)
-{
+CtrlrPropertyComponent::CtrlrPropertyComponent(const Identifier &_propertyName, const ValueTree &_propertyElement,
+											   const ValueTree &_identifierDefinition, CtrlrPanel *_panel,
+											   StringArray *_possibleChoices, Array<var> *_possibleValues)
+	: PropertyComponent(_propertyName.toString()),
+	  identifierDefinition(_identifierDefinition),
+	  propertyName(_propertyName),
+	  propertyElement(_propertyElement),
+	  panel(_panel) {
+	if (_possibleChoices != nullptr)
+		possibleChoices = *_possibleChoices;
 
-//    if (propertyName == Ids::midiMessageCtrlrValue) // ADDED v5.6.35. For Multi MIDI Message. Thanks to @dnaldoog
-//    {
-//        setVisible(false); // this hides the midi message ctrlr value slider because @dnaldoog doesn't think it does anything
-//        visibleText = identifierDefinition.isValid() ? identifierDefinition.getProperty("text").toString()
-//        : propertyName.toString();
-//        visibleText.clear();
-//        propertyType = CtrlrIDManager::Numeric;
-//        return;
-//    }
+	if (_possibleValues != nullptr)
+		possibleValues = *_possibleValues;
 
-    if (propertyName == Ids::midiMessageCtrlrNumber)
-    {
-        propertyElement.addListener(this);
-    }
-    
-    if (!identifierDefinition.isValid())
+	//    if (propertyName == Ids::midiMessageCtrlrValue) // ADDED v5.6.35. For Multi MIDI Message. Thanks to @dnaldoog
+	//    {
+	//        setVisible(false); // this hides the midi message ctrlr value slider because @dnaldoog doesn't think it
+	//        does anything visibleText = identifierDefinition.isValid() ?
+	//        identifierDefinition.getProperty("text").toString() : propertyName.toString(); visibleText.clear();
+	//        propertyType = CtrlrIDManager::Numeric;
+	//        return;
+	//    }
+
+	if (propertyName == Ids::midiMessageCtrlrNumber) {
+		propertyElement.addListener(this);
+	}
+
+	if (!identifierDefinition.isValid())
 	{
 		addAndMakeVisible (new CtrlrUnknownPropertyComponent (propertyName, propertyElement, identifierDefinition));
 		visibleText	 = propertyName.toString();
@@ -141,23 +138,20 @@ Component *CtrlrPropertyComponent::getPropertyComponent()
     _DBG("Property Name: " + propertyName.toString() + " | XML Type: " + identifierDefinition.getProperty("type").toString() + " | Mapped Type: " + String(propertyType));
     if (propertyName == Ids::componentLayerUid)
     {
-        possibleChoices = new StringArray();
-        possibleValues = new Array<var>();
+		possibleChoices.clear();
+		possibleValues.clear();
 
-        if (panel != nullptr && panel->getCanvas() != nullptr)
-        {
-            CtrlrPanelCanvas* canvas = panel->getCanvas();
-            for (int i = 0; i < canvas->getNumLayers(); i++)
-            {
-                CtrlrPanelCanvasLayer* layer = canvas->getLayerFromArray(i);
-                if (layer != nullptr)
-                {
-                    possibleChoices->add(layer->getProperty(Ids::uiPanelCanvasLayerName).toString());
-                    possibleValues->add(layer->getProperty(Ids::uiPanelCanvasLayerUid).toString());
-                }
-            }
-        }
-    }
+		if (panel != nullptr && panel->getCanvas() != nullptr) {
+			CtrlrPanelCanvas *canvas = panel->getCanvas();
+			for (int i = 0; i < canvas->getNumLayers(); i++) {
+				CtrlrPanelCanvasLayer *layer = canvas->getLayerFromArray(i);
+				if (layer != nullptr) {
+					possibleChoices.add(layer->getProperty(Ids::uiPanelCanvasLayerName).toString());
+					possibleValues.add(layer->getProperty(Ids::uiPanelCanvasLayerUid).toString());
+				}
+			}
+		}
+	}
     _DBG("CtrlrPropertyComponent::getPropertyComponent [POST] propertyType==" + String((int)propertyType) + " visibleText==" + visibleText);
     
     // END of addon
@@ -173,10 +167,10 @@ Component *CtrlrPropertyComponent::getPropertyComponent()
     
     if (propertyName == Ids::componentBubbleHelpTrigger) // Added v5.6.36. Thanks to @dnaldoog
 	{
-        possibleChoices = new StringArray();
-        possibleValues = new Array<var>();
-        
-        // Automatically parse the "defaults" attribute from the XML line
+		possibleChoices.clear();
+		possibleValues.clear();
+
+		// Automatically parse the "defaults" attribute from the XML line
         String defaultsString = identifierDefinition.getProperty("defaults").toString();
         StringArray pairs;
         pairs.addTokens(defaultsString, ",", "");
@@ -187,9 +181,9 @@ Component *CtrlrPropertyComponent::getPropertyComponent()
             kv.addTokens(pairs[i], "=", "");
             if (kv.size() == 2)
             {
-                possibleChoices->add(kv[0].trim());
-                possibleValues->add(kv[1].trim().getIntValue());
-            }
+				possibleChoices.add(kv[0].trim());
+				possibleValues.add(kv[1].trim().getIntValue());
+			}
         }
     }
 	
@@ -281,13 +275,13 @@ Component *CtrlrPropertyComponent::getPropertyComponent()
 		case CtrlrIDManager::VarNumeric:
             // preferredHeight = 36;
             preferredHeight = roundDoubleToInt(propertyLineheightBaseValue * 1.0); // Updated v5.6.33.
-			return (new CtrlrChoicePropertyComponent(valueToControl, possibleChoices, possibleValues, true));
-            
+			return (new CtrlrChoicePropertyComponent(valueToControl, &possibleChoices, &possibleValues, true));
+
 		case CtrlrIDManager::VarText:
             // preferredHeight = 36;
             preferredHeight = roundDoubleToInt(propertyLineheightBaseValue * 1.0); // Updated v5.6.33.
-			return (new CtrlrChoicePropertyComponent(valueToControl, possibleChoices, possibleValues, false));
-            
+			return (new CtrlrChoicePropertyComponent(valueToControl, &possibleChoices, &possibleValues, false));
+
 		case CtrlrIDManager::FileProperty:
             // preferredHeight = 36;
             preferredHeight = roundDoubleToInt(propertyLineheightBaseValue * 1.0); // Updated v5.6.33.

--- a/Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.h
+++ b/Source/UIComponents/CtrlrPropertyEditors/CtrlrPropertyComponent.h
@@ -60,8 +60,8 @@ class CtrlrPropertyComponent  : public PropertyComponent, public ValueTree::List
 		Font currentFont;
 		CtrlrIDManager::PropertyType propertyType;
 		CtrlrPanel *panel;
-		StringArray *possibleChoices;
-		Array<var>  *possibleValues;
+		StringArray possibleChoices;
+		Array<var> possibleValues;
 		URL url;
 		String urlString;
 };

--- a/Tests/known_failures_macos.txt
+++ b/Tests/known_failures_macos.txt
@@ -16,15 +16,6 @@ MidiRouting.h2d_host_cc_reaches_device_once_and_host_once
 MidiRouting.pause_in_blocks_host_echo
 MidiLua.device_input_invokes_lua_multiMidiReceived_once
 
-# macOS-only. A device-injected CC is correctly delivered into CtrlrX by the CoreMIDI mock (proven:
-# the sibling device-input tests -- d2d, device_input_matching, roundtrip, MidiLua device/host input
-# -- all pass, so the input reaches CtrlrX's comparator/Lua/device paths), but the D2H thru-to-host
-# copy never appears on the host output. It is *lost*, not merely delayed: draining ~40 blocks (~1s)
-# still yields 0. Passes on Linux and Windows with identical mock/test code, so this is a genuine
-# macOS-specific CtrlrX MIDI-timestamp/handling issue (CtrlrX MIDI handling is out of scope for this
-# PR), not a mock defect.
-MidiRouting.d2h_injected_cc_reaches_host_once
-
 # NOTE: a couple of Lua.* tests (e.g. Lua.lua_global_objects_and_panel_bindings_available) can
 # intermittently hit the ctest 120s TIMEOUT under runner load (time is not mocked). A timed-out test
 # emits no JUnit XML, so it is invisible to ci_check_test_results.py and cannot be allowlisted here;

--- a/Tests/mock_MidiDeviceAlsa.cpp
+++ b/Tests/mock_MidiDeviceAlsa.cpp
@@ -37,55 +37,51 @@ InformMockMidiOfSubsystem mockMidiSubsystem;
  *    derives timestamps from a sequencer queue; we provide a minimal fake queue with a fixed
  *    real-time base so injected input gets sensible (wall-clock) timestamps.
  */
-struct FakeSndSeqState
-{
-    static constexpr int applicationClientId = 1;
+struct FakeSndSeqState {
+		static constexpr int applicationClientId = 1;
 
-    int device_number = -1;
-    int device_port_number = -1;
-    // JUCE 6's input router dispatches by ports[event->dest.port], where the index is the portId
-    // returned by snd_seq_create_simple_port and JUCE's OwnedArray::set() *appends* when the id is
-    // past the end. So the app port ids must start at 0 and increment in lockstep with JUCE's port
-    // array, or incoming events get an out-of-range dest.port and are dropped. (Real ALSA hands an
-    // app its first port id 0 as well.)
-    unsigned char application_port_number = 0;
-    std::map<unsigned char, std::tuple<int, int>> application_to_device_port_map{};
+		int device_number = -1;
+		int device_port_number = -1;
+		// JUCE 6's input router dispatches by ports[event->dest.port], where the index is the portId
+		// returned by snd_seq_create_simple_port and JUCE's OwnedArray::set() *appends* when the id is
+		// past the end. So the app port ids must start at 0 and increment in lockstep with JUCE's port
+		// array, or incoming events get an out-of-range dest.port and are dropped. (Real ALSA hands an
+		// app its first port id 0 as well.)
+		unsigned char application_port_number = 0;
+		std::map<unsigned char, std::tuple<int, int>> application_to_device_port_map{};
 
-    // Async-enumeration / input plumbing:
-    int eventfd = -1;                  // real fd handed to JUCE's poll() so we can wake its input thread
-    bool pendingSystemEvent = false;   // deliver one PORT_START at startup to trigger enumeration
-    int queueId = 0;                   // fake sequencer queue id
-    snd_seq_real_time_t queueStartReal{0, 0};  // queue real-time base (startTimeNative for JUCE)
-    juce::uint32 queueStartMillis = 0; // wall clock captured when the queue starts (~JUCE's startTimeMillis)
-    unsigned char inputAppPort = 0;    // app port id last used to subscribe an input (device->host)
+		// Async-enumeration / input plumbing:
+		int eventfd = -1;						  // real fd handed to JUCE's poll() so we can wake its input thread
+		bool pendingSystemEvent = false;		  // deliver one PORT_START at startup to trigger enumeration
+		int queueId = 0;						  // fake sequencer queue id
+		snd_seq_real_time_t queueStartReal{0, 0}; // queue real-time base (startTimeNative for JUCE)
+		juce::uint32 queueStartMillis = 0;		  // wall clock captured when the queue starts (~JUCE's startTimeMillis)
+		unsigned char inputAppPort = 0;			  // app port id last used to subscribe an input (device->host)
 };
 
 static FakeSndSeqState fakeHandle;
 
 // Wakes JUCE's input thread by making its poll() fd readable.
-static void signalFakeEventFd()
-{
-    if (fakeHandle.eventfd >= 0)
-    {
-        uint64_t one = 1;
-        [[maybe_unused]] auto ignored = ::write(fakeHandle.eventfd, &one, sizeof(one));
-    }
+static void signalFakeEventFd() {
+	if (fakeHandle.eventfd >= 0) {
+		uint64_t one = 1;
+		[[maybe_unused]] auto ignored = ::write(fakeHandle.eventfd, &one, sizeof(one));
+	}
 }
 
 // Resets the poll() fd so JUCE's next poll() blocks again (call when there's nothing left to deliver).
-static void drainFakeEventFd()
-{
-    if (fakeHandle.eventfd >= 0)
-    {
-        uint64_t value = 0;
-        [[maybe_unused]] auto ignored = ::read(fakeHandle.eventfd, &value, sizeof(value));
-    }
+static void drainFakeEventFd() {
+	if (fakeHandle.eventfd >= 0) {
+		uint64_t value = 0;
+		[[maybe_unused]] auto ignored = ::read(fakeHandle.eventfd, &value, sizeof(value));
+	}
 }
 
 // Register, once at load, how MockMidi::injectMidiInput should wake our (ALSA) input thread.
-static struct RegisterAlsaInputNotifier
-{
-    RegisterAlsaInputNotifier() { MockMidi::setSubsystemInputNotifier(signalFakeEventFd); }
+static struct RegisterAlsaInputNotifier {
+		RegisterAlsaInputNotifier() {
+			MockMidi::setSubsystemInputNotifier(signalFakeEventFd);
+		}
 } registerAlsaInputNotifier;
 
 /*
@@ -95,32 +91,27 @@ static struct RegisterAlsaInputNotifier
  * Midi output to device
  **************************************************************/
 std::shared_ptr<juce::MidiMessage> lastEncodedMidiMessage;
-long snd_midi_event_encode(snd_midi_event_t *dev, const unsigned char *buf, long count, snd_seq_event_t *ev)
-{
-    lastEncodedMidiMessage = std::make_shared<juce::MidiMessage>(buf, count);
-    return count;
+long snd_midi_event_encode(snd_midi_event_t *dev, const unsigned char *buf, long count, snd_seq_event_t *ev) {
+	lastEncodedMidiMessage = std::make_shared<juce::MidiMessage>(buf, count);
+	return count;
 }
 
-int snd_seq_event_output_direct(snd_seq_t *handle, snd_seq_event_t *ev)
-{
-    auto mapIter = fakeHandle.application_to_device_port_map.find(ev->source.port);
-    if (mapIter == fakeHandle.application_to_device_port_map.end())
-        return 0; // not a routed application port (e.g. the announce port), ignore
+int snd_seq_event_output_direct(snd_seq_t *handle, snd_seq_event_t *ev) {
+	auto mapIter = fakeHandle.application_to_device_port_map.find(ev->source.port);
+	if (mapIter == fakeHandle.application_to_device_port_map.end())
+		return 0; // not a routed application port (e.g. the announce port), ignore
 
-    // JUCE's MidiOutput flushes queued messages on a background thread that can outlive the test
-    // (and its per-test StrictMock). If there's no current mock, there's nothing to record -- drop
-    // the late send rather than dereferencing a null instance (a source of teardown segfaults).
-    MockMidi *mock = MockMidi::getInstance();
-    if (mock == nullptr)
-        return 0;
+	// JUCE's MidiOutput flushes queued messages on a background thread that can outlive the test
+	// (and its per-test StrictMock). If there's no current mock, there's nothing to record -- drop
+	// the late send rather than dereferencing a null instance (a source of teardown segfaults).
+	MockMidi *mock = MockMidi::getInstance();
+	if (mock == nullptr)
+		return 0;
 
-    int event_device_number = std::get<0>(mapIter->second);
-    int event_device_port_number = std::get<1>(mapIter->second);
-    mock->sendMidiEvent(
-        event_device_number,
-        event_device_port_number,
-        *lastEncodedMidiMessage);
-    return lastEncodedMidiMessage->getRawDataSize();
+	int event_device_number = std::get<0>(mapIter->second);
+	int event_device_port_number = std::get<1>(mapIter->second);
+	mock->sendMidiEvent(event_device_number, event_device_port_number, *lastEncodedMidiMessage);
+	return lastEncodedMidiMessage->getRawDataSize();
 }
 
 /**************************************************************
@@ -132,76 +123,71 @@ int snd_seq_event_output_direct(snd_seq_t *handle, snd_seq_event_t *ev)
  *  - decline UMP for client setup / input / endpoint enumeration (so JUCE uses the MIDI 1.0
  *    bytestream path for enumeration and input), and
  *  - translate UMP output back to a MidiMessage and route it like the bytestream output would.
+ *
+ * NOTE (JUCE 6 -> 8): JUCE 8's ALSA output sends *everything* as UMP when
+ * snd_seq_ump_event_output_direct is non-null (juce_Midi_linux.cpp, OutputImplNative::send), which
+ * it always is here because this file defines it.
+ * Reassembly is delegated to JUCE's own ump::ToBytestreamConverter.
+ *
+ * The whole section is compiled only where it can be needed: JUCE 6 has no UMP support at all (and
+ * never calls these symbols), and on libasound < 1.2.10 the UMP symbols do not exist, so JUCE's
+ * weak references are null and it uses the snd_midi_event_encode bytestream path above.
  **************************************************************/
-// Convert a single UMP word (MIDI 1.0 channel-voice / system) to a juce::MidiMessage.
-static bool umpWordToMidiMessage(unsigned int word, juce::MidiMessage &out)
-{
-    const int messageType = (int)((word >> 28) & 0xF);
-    if (messageType != 0x2 && messageType != 0x1) // MIDI 1.0 channel voice / system
-        return false;
+#if JUCE_MAJOR_VERSION >= 8 && defined(SND_LIB_VERSION) && SND_LIB_VERSION >= SND_LIB_VER(1, 2, 10)
 
-    const juce::uint8 status = (juce::uint8)((word >> 16) & 0xFF);
-    const juce::uint8 data1 = (juce::uint8)((word >> 8) & 0xFF);
-    const juce::uint8 data2 = (juce::uint8)(word & 0xFF);
+// Must outlive individual calls: a SysEx7 stream arrives as several packets (start / continue /
+// end) across successive snd_seq_ump_event_output_direct() calls and the translator holds the
+// partial message between them. Only JUCE's (single) MidiOutput background thread reaches this.
+static juce::ump::ToBytestreamConverter umpToBytestream{4096};
 
-    const int length = juce::MidiMessage::getMessageLengthFromFirstByte(status);
-    if (length <= 1)
-        out = juce::MidiMessage(status);
-    else if (length == 2)
-        out = juce::MidiMessage(status, data1);
-    else
-        out = juce::MidiMessage(status, data1, data2);
-    return true;
+int snd_seq_set_client_midi_version(snd_seq_t *seq, int midi_version) {
+	return 0;
 }
 
-int snd_seq_set_client_midi_version(snd_seq_t *seq, int midi_version) { return 0; }
-
-int snd_seq_ump_event_input(snd_seq_t *seq, snd_seq_ump_event_t **ev)
-{
-    return -1; // decline: make JUCE fall back to snd_seq_event_input (bytestream)
+int snd_seq_ump_event_input(snd_seq_t *seq, snd_seq_ump_event_t **ev) {
+	return -1; // decline: make JUCE fall back to snd_seq_event_input (bytestream)
 }
 
-int snd_seq_get_ump_endpoint_info(snd_seq_t *seq, int client, void *info)
-{
-    return -1; // decline: our fake devices aren't UMP, so JUCE enumerates them as MIDI 1.0 proxies
+int snd_seq_get_ump_endpoint_info(snd_seq_t *seq, int client, void *info) {
+	return -1; // decline: our fake devices aren't UMP, so JUCE enumerates them as MIDI 1.0 proxies
 }
 
-int snd_seq_ump_event_output_direct(snd_seq_t *seq, snd_seq_ump_event_t *ev)
-{
-    auto mapIter = fakeHandle.application_to_device_port_map.find(ev->source.port);
-    if (mapIter == fakeHandle.application_to_device_port_map.end())
-        return 0; // not a routed application port (e.g. the announce port), ignore
+int snd_seq_ump_event_output_direct(snd_seq_t *seq, snd_seq_ump_event_t *ev) {
+	auto mapIter = fakeHandle.application_to_device_port_map.find(ev->source.port);
+	if (mapIter == fakeHandle.application_to_device_port_map.end())
+		return 0; // not a routed application port (e.g. the announce port), ignore
 
-    juce::MidiMessage message;
-    if (!umpWordToMidiMessage(ev->ump[0], message))
-        return 0; // sysex / MIDI 2.0 not handled by this mock
+	MockMidi *mock = MockMidi::getInstance();
+	if (mock == nullptr)
+		return 0; // background-thread flush after the test's mock was destroyed; drop it (see above)
 
-    MockMidi *mock = MockMidi::getInstance();
-    if (mock == nullptr)
-        return 0; // background-thread flush after the test's mock was destroyed; drop it (see above)
+	const int event_device_number = std::get<0>(mapIter->second);
+	const int event_device_port_number = std::get<1>(mapIter->second);
 
-    mock->sendMidiEvent(
-        std::get<0>(mapIter->second),
-        std::get<1>(mapIter->second),
-        message);
-    return 1;
+	// Emits nothing for the intermediate packets of a multi-packet (SysEx7) message, and once for
+	// each complete bytestream message.
+	umpToBytestream.convert(juce::ump::View{ev->ump}, 0.0, [&](juce::ump::BytesOnGroup message, double) {
+		mock->sendMidiEvent(event_device_number, event_device_port_number,
+							juce::MidiMessage(message.bytes.data(), (int)message.bytes.size()));
+	});
+	return 1;
 }
 
-long snd_midi_event_decode(snd_midi_event_t *dev, unsigned char *buf, long count, const snd_seq_event_t *ev)
-{
-    MockMidi *mock = MockMidi::getInstance();
-    if (mock == nullptr)
-        return 0;
+#endif // JUCE 8 + libasound >= 1.2.10
 
-    std::lock_guard<std::mutex> lock(mock->inputMutex);
-    if (!mock->waitingMidiInput.empty())
-    {
-        juce::MidiMessage message = mock->waitingMidiInput.front();
-        std::memcpy(buf, message.getRawData(), message.getRawDataSize());
-        mock->waitingMidiInput.pop_front();
-        return message.getRawDataSize();
-    }
-    return 0;
+long snd_midi_event_decode(snd_midi_event_t *dev, unsigned char *buf, long count, const snd_seq_event_t *ev) {
+	MockMidi *mock = MockMidi::getInstance();
+	if (mock == nullptr)
+		return 0;
+
+	std::lock_guard<std::mutex> lock(mock->inputMutex);
+	if (!mock->waitingMidiInput.empty()) {
+		juce::MidiMessage message = mock->waitingMidiInput.front();
+		std::memcpy(buf, message.getRawData(), message.getRawDataSize());
+		mock->waitingMidiInput.pop_front();
+		return message.getRawDataSize();
+	}
+	return 0;
 }
 void snd_midi_event_reset_decode(snd_midi_event_t *dev) {}
 
@@ -213,254 +199,254 @@ void snd_midi_event_reset_encode(snd_midi_event_t *dev) {}
 // JUCE 8's input thread does: snd_midi_event_new -> ... -> snd_midi_event_free.
 // We don't use a real parser; we just hand back a non-null token so JUCE's null/error checks pass.
 static char fakeMidiEventParser = 0;
-int snd_midi_event_new(size_t bufsize, snd_midi_event_t **rdev)
-{
-    if (rdev != nullptr)
-        *rdev = reinterpret_cast<snd_midi_event_t *>(&fakeMidiEventParser);
-    return 0;
+int snd_midi_event_new(size_t bufsize, snd_midi_event_t **rdev) {
+	if (rdev != nullptr)
+		*rdev = reinterpret_cast<snd_midi_event_t *>(&fakeMidiEventParser);
+	return 0;
 }
 void snd_midi_event_free(snd_midi_event_t *dev) {}
 void snd_midi_event_no_status(snd_midi_event_t *dev, int on) {}
 
-int snd_seq_event_input(snd_seq_t *handle, snd_seq_event_t **ev)
-{
-    static snd_seq_event_t fakeEvent; // only the (single) Sequencer input thread calls this
-    std::memset(&fakeEvent, 0, sizeof(fakeEvent));
+int snd_seq_event_input(snd_seq_t *handle, snd_seq_event_t **ev) {
+	static snd_seq_event_t fakeEvent; // only the (single) Sequencer input thread calls this
+	std::memset(&fakeEvent, 0, sizeof(fakeEvent));
 
-    MockMidi *mock = MockMidi::getInstance();
+	MockMidi *mock = MockMidi::getInstance();
 
-    std::unique_lock<std::mutex> lock;
-    if (mock != nullptr)
-        lock = std::unique_lock<std::mutex>(mock->inputMutex);
+	std::unique_lock<std::mutex> lock;
+	if (mock != nullptr)
+		lock = std::unique_lock<std::mutex>(mock->inputMutex);
 
-    // 1) Startup system event: makes JUCE (re)scan ports via findEndpoints().
-    if (fakeHandle.pendingSystemEvent)
-    {
-        fakeHandle.pendingSystemEvent = false;
-        fakeEvent.type = SND_SEQ_EVENT_PORT_START;
-        fakeEvent.source.client = SND_SEQ_CLIENT_SYSTEM;
-        fakeEvent.source.port = SND_SEQ_PORT_SYSTEM_ANNOUNCE;
-        *ev = &fakeEvent;
-        return 0;
-    }
+	// 1) Startup system event: makes JUCE (re)scan ports via findEndpoints().
+	if (fakeHandle.pendingSystemEvent) {
+		fakeHandle.pendingSystemEvent = false;
+		fakeEvent.type = SND_SEQ_EVENT_PORT_START;
+		fakeEvent.source.client = SND_SEQ_CLIENT_SYSTEM;
+		fakeEvent.source.port = SND_SEQ_PORT_SYSTEM_ANNOUNCE;
+		*ev = &fakeEvent;
+		return 0;
+	}
 
-    // 2) Pending injected MIDI input from a (fake) device.
-    if (mock != nullptr && !mock->waitingMidiInput.empty())
-    {
-        // Build a real-time, absolute, queued (non-direct) event so JUCE computes a wall-clock
-        // timestamp relative to the queue's real-time base (which we report as 0).
-        const juce::uint32 elapsedMillis = juce::Time::getMillisecondCounter() - fakeHandle.queueStartMillis;
-        fakeEvent.type = SND_SEQ_EVENT_NOTEON; // any non-system type; the bytes come from decode()
-        fakeEvent.flags = SND_SEQ_TIME_STAMP_REAL | SND_SEQ_TIME_MODE_ABS;
-        fakeEvent.queue = (unsigned char) fakeHandle.queueId; // not SND_SEQ_QUEUE_DIRECT
-        fakeEvent.time.time.tv_sec = elapsedMillis / 1000;
-        fakeEvent.time.time.tv_nsec = (elapsedMillis % 1000) * 1000000u;
-        fakeEvent.source.client = (unsigned char) std::get<0>(
-            fakeHandle.application_to_device_port_map.count(fakeHandle.inputAppPort)
-                ? fakeHandle.application_to_device_port_map[fakeHandle.inputAppPort]
-                : std::make_tuple(0, 0));
-        fakeEvent.dest.client = FakeSndSeqState::applicationClientId;
-        fakeEvent.dest.port = fakeHandle.inputAppPort; // route to the subscribed input Port
-        *ev = &fakeEvent;
-        return 0;
-    }
+	// 2) Pending injected MIDI input from a (fake) device.
+	if (mock != nullptr && !mock->waitingMidiInput.empty()) {
+		// Build a real-time, absolute, queued (non-direct) event so JUCE computes a wall-clock
+		// timestamp relative to the queue's real-time base (which we report as 0).
+		const juce::uint32 elapsedMillis = juce::Time::getMillisecondCounter() - fakeHandle.queueStartMillis;
+		fakeEvent.type = SND_SEQ_EVENT_NOTEON; // any non-system type; the bytes come from decode()
+		fakeEvent.flags = SND_SEQ_TIME_STAMP_REAL | SND_SEQ_TIME_MODE_ABS;
+		fakeEvent.queue = (unsigned char)fakeHandle.queueId; // not SND_SEQ_QUEUE_DIRECT
+		fakeEvent.time.time.tv_sec = elapsedMillis / 1000;
+		fakeEvent.time.time.tv_nsec = (elapsedMillis % 1000) * 1000000u;
+		fakeEvent.source.client =
+			(unsigned char)std::get<0>(fakeHandle.application_to_device_port_map.count(fakeHandle.inputAppPort)
+										   ? fakeHandle.application_to_device_port_map[fakeHandle.inputAppPort]
+										   : std::make_tuple(0, 0));
+		fakeEvent.dest.client = FakeSndSeqState::applicationClientId;
+		fakeEvent.dest.port = fakeHandle.inputAppPort; // route to the subscribed input Port
+		*ev = &fakeEvent;
+		return 0;
+	}
 
-    // 3) Nothing to deliver: reset the poll() fd so JUCE's next poll() blocks.
-    drainFakeEventFd();
-    return -EAGAIN;
+	// 3) Nothing to deliver: reset the poll() fd so JUCE's next poll() blocks.
+	drainFakeEventFd();
+	return -EAGAIN;
 }
 
-int snd_seq_free_event(snd_seq_event_t *ev)
-{
-    // snd_seq_event_input is supposed to allocate the pointer to 'ev'.
-    // Since we hand back a static event, there's nothing to free.
-    return 0;
+int snd_seq_free_event(snd_seq_event_t *ev) {
+	// snd_seq_event_input is supposed to allocate the pointer to 'ev'.
+	// Since we hand back a static event, there's nothing to free.
+	return 0;
 }
 
-int snd_seq_event_input_pending(snd_seq_t *seq, int fetch_sequencer)
-{
-    // should return the byte-size of pending events
-    MockMidi *mock = MockMidi::getInstance();
-    if (mock == nullptr)
-        return 0;
+int snd_seq_event_input_pending(snd_seq_t *seq, int fetch_sequencer) {
+	// should return the byte-size of pending events
+	MockMidi *mock = MockMidi::getInstance();
+	if (mock == nullptr)
+		return 0;
 
-    std::lock_guard<std::mutex> lock(mock->inputMutex);
-    int numBytes = 0;
-    for (const auto &message : mock->waitingMidiInput)
-        numBytes += message.getRawDataSize();
-    return numBytes;
+	std::lock_guard<std::mutex> lock(mock->inputMutex);
+	int numBytes = 0;
+	for (const auto &message : mock->waitingMidiInput)
+		numBytes += message.getRawDataSize();
+	return numBytes;
 }
 
 /**************************************************************
  * Sequencer queue (used by JUCE 8 for input timestamps)
  **************************************************************/
-int snd_seq_alloc_queue(snd_seq_t *handle) { return fakeHandle.queueId; }
-int snd_seq_free_queue(snd_seq_t *handle, int q) { return 0; }
-// snd_seq_start_queue / snd_seq_stop_queue are macros over snd_seq_control_queue, so mock that.
-int snd_seq_control_queue(snd_seq_t *seq, int q, int type, int value, snd_seq_event_t *ev)
-{
-    if (type == SND_SEQ_EVENT_START)
-    {
-        // Capture a wall-clock reference ~when JUCE captures its own startTimeMillis.
-        fakeHandle.queueStartMillis = juce::Time::getMillisecondCounter();
-        fakeHandle.queueStartReal = snd_seq_real_time_t{0, 0};
-    }
-    return 0;
+int snd_seq_alloc_queue(snd_seq_t *handle) {
+	return fakeHandle.queueId;
 }
-int snd_seq_drain_output(snd_seq_t *handle) { return 0; }
-int snd_seq_get_queue_status(snd_seq_t *handle, int q, snd_seq_queue_status_t *status) { return 0; }
-const snd_seq_real_time_t *snd_seq_queue_status_get_real_time(const snd_seq_queue_status_t *info)
-{
-    // We shadow the real getter, so the (opaque) status struct doesn't need to be populated.
-    return &fakeHandle.queueStartReal;
+int snd_seq_free_queue(snd_seq_t *handle, int q) {
+	return 0;
+}
+// snd_seq_start_queue / snd_seq_stop_queue are macros over snd_seq_control_queue, so mock that.
+int snd_seq_control_queue(snd_seq_t *seq, int q, int type, int value, snd_seq_event_t *ev) {
+	if (type == SND_SEQ_EVENT_START) {
+		// Capture a wall-clock reference ~when JUCE captures its own startTimeMillis.
+		fakeHandle.queueStartMillis = juce::Time::getMillisecondCounter();
+		fakeHandle.queueStartReal = snd_seq_real_time_t{0, 0};
+	}
+	return 0;
+}
+int snd_seq_drain_output(snd_seq_t *handle) {
+	return 0;
+}
+int snd_seq_get_queue_status(snd_seq_t *handle, int q, snd_seq_queue_status_t *status) {
+	return 0;
+}
+const snd_seq_real_time_t *snd_seq_queue_status_get_real_time(const snd_seq_queue_status_t *info) {
+	// We shadow the real getter, so the (opaque) status struct doesn't need to be populated.
+	return &fakeHandle.queueStartReal;
 }
 
 /**************************************************************
  * poll() descriptors -- hand JUCE a real, signalable fd
  **************************************************************/
-int snd_seq_poll_descriptors_count(snd_seq_t *handle, short events) { return 1; }
-int snd_seq_poll_descriptors(snd_seq_t *handle, struct pollfd *pfds, unsigned int space, short events)
-{
-    if (pfds == nullptr || space < 1)
-        return 0;
-    pfds[0].fd = fakeHandle.eventfd;
-    pfds[0].events = POLLIN;
-    pfds[0].revents = 0;
-    return 1;
+int snd_seq_poll_descriptors_count(snd_seq_t *handle, short events) {
+	return 1;
+}
+int snd_seq_poll_descriptors(snd_seq_t *handle, struct pollfd *pfds, unsigned int space, short events) {
+	if (pfds == nullptr || space < 1)
+		return 0;
+	pfds[0].fd = fakeHandle.eventfd;
+	pfds[0].events = POLLIN;
+	pfds[0].revents = 0;
+	return 1;
 }
 
 /**************************************************************
  * Port iteration and opening stuff
  **************************************************************/
-int snd_seq_open(snd_seq_t **handle, const char *name, int streams, int mode)
-{
-    *handle = (snd_seq_t *)&fakeHandle;
-    // assert name == "default"
-    // assert streams = SND_SEQ_OPEN_DUPLEX
-    // assert mode = 0
+int snd_seq_open(snd_seq_t **handle, const char *name, int streams, int mode) {
+	*handle = (snd_seq_t *)&fakeHandle;
+	// assert name == "default"
+	// assert streams = SND_SEQ_OPEN_DUPLEX
+	// assert mode = 0
 
-    // A fresh client (JUCE's AlsaClient singleton is destroyed/recreated between tests) starts its
-    // port numbering at 0 and has an empty port table. Reset here so the app port ids the mock hands
-    // out stay aligned with JUCE's freshly-rebuilt ports[] array (it dispatches input by portId, see
-    // application_port_number above); otherwise incoming events get an out-of-range dest.port.
-    fakeHandle.application_port_number = 0;
-    fakeHandle.inputAppPort = 0;
-    fakeHandle.application_to_device_port_map.clear();
+	// A fresh client (JUCE's AlsaClient singleton is destroyed/recreated between tests) starts its
+	// port numbering at 0 and has an empty port table. Reset here so the app port ids the mock hands
+	// out stay aligned with JUCE's freshly-rebuilt ports[] array (it dispatches input by portId, see
+	// application_port_number above); otherwise incoming events get an out-of-range dest.port.
+	fakeHandle.application_port_number = 0;
+	fakeHandle.inputAppPort = 0;
+	fakeHandle.application_to_device_port_map.clear();
 
-    if (fakeHandle.eventfd < 0)
-        fakeHandle.eventfd = ::eventfd(0, EFD_NONBLOCK);
-    // Trigger one initial port-change so JUCE performs its (async) device enumeration.
-    fakeHandle.pendingSystemEvent = true;
-    signalFakeEventFd();
-    return 0;
+	if (fakeHandle.eventfd < 0)
+		fakeHandle.eventfd = ::eventfd(0, EFD_NONBLOCK);
+	// Trigger one initial port-change so JUCE performs its (async) device enumeration.
+	fakeHandle.pendingSystemEvent = true;
+	signalFakeEventFd();
+	return 0;
 }
-int snd_seq_nonblock(snd_seq_t *handle, int nonblock)
-{
-    return 0;
+int snd_seq_nonblock(snd_seq_t *handle, int nonblock) {
+	return 0;
 }
-int snd_seq_set_client_name(snd_seq_t *seq, const char *name) { return 0; }
-int snd_seq_client_id(snd_seq_t *handle)
-{
-    return FakeSndSeqState::applicationClientId;
+int snd_seq_set_client_name(snd_seq_t *seq, const char *name) {
+	return 0;
 }
-int snd_seq_close(snd_seq_t *handle)
-{
-    fakeHandle.device_number = -1;
-    fakeHandle.device_port_number = -1;
-    if (fakeHandle.eventfd >= 0)
-    {
-        ::close(fakeHandle.eventfd);
-        fakeHandle.eventfd = -1;
-    }
-    return 0;
+int snd_seq_client_id(snd_seq_t *handle) {
+	return FakeSndSeqState::applicationClientId;
+}
+int snd_seq_close(snd_seq_t *handle) {
+	fakeHandle.device_number = -1;
+	fakeHandle.device_port_number = -1;
+	if (fakeHandle.eventfd >= 0) {
+		::close(fakeHandle.eventfd);
+		fakeHandle.eventfd = -1;
+	}
+	return 0;
 }
 
 // Client / port info reads on our fake handle (JUCE 8 uses these during enumeration / port setup).
-int snd_seq_get_client_info(snd_seq_t *handle, snd_seq_client_info_t *info) { return 0; }
-int snd_seq_get_any_client_info(snd_seq_t *handle, int client, snd_seq_client_info_t *info) { return 0; }
+int snd_seq_get_client_info(snd_seq_t *handle, snd_seq_client_info_t *info) {
+	return 0;
+}
+int snd_seq_get_any_client_info(snd_seq_t *handle, int client, snd_seq_client_info_t *info) {
+	return 0;
+}
 // Return non-zero so JUCE skips the (UMP-only) per-port detail loop, which would otherwise call
 // weak UMP getters that are intentionally left undefined (nullptr) in this mock.
-int snd_seq_get_any_port_info(snd_seq_t *handle, int client, int port, snd_seq_port_info_t *info) { return -1; }
-const char *snd_seq_client_info_get_name(snd_seq_client_info_t *info)
-{
-    static const char *name = "CtrlrX Mock";
-    return name;
+int snd_seq_get_any_port_info(snd_seq_t *handle, int client, int port, snd_seq_port_info_t *info) {
+	return -1;
+}
+const char *snd_seq_client_info_get_name(snd_seq_client_info_t *info) {
+	static const char *name = "CtrlrX Mock";
+	return name;
 }
 
 void snd_seq_port_info_set_client(snd_seq_port_info_t *info, int client) {}
 void snd_seq_port_info_set_port(snd_seq_port_info_t *info, int port) {}
 
-int snd_seq_system_info(snd_seq_t *handle, snd_seq_system_info_t *info)
-{
-    // (Legacy / JUCE 6) kept for backward compatibility.
-    if (handle != NULL && info != NULL)
-    {
-        fakeHandle.device_number = -1; // start of iteration
-        return 0;
-    }
-    return 1;
+int snd_seq_system_info(snd_seq_t *handle, snd_seq_system_info_t *info) {
+	// (Legacy / JUCE 6) kept for backward compatibility.
+	if (handle != NULL && info != NULL) {
+		fakeHandle.device_number = -1; // start of iteration
+		return 0;
+	}
+	return 1;
 }
 
-int snd_seq_system_info_get_cur_clients(const snd_seq_system_info_t *info)
-{
-    // (Legacy / JUCE 6) kept for backward compatibility.
-    fakeHandle.device_number = -1; // start of iteration
-    return MockMidi::getInstance()->getNumDevices();
+int snd_seq_system_info_get_cur_clients(const snd_seq_system_info_t *info) {
+	// (Legacy / JUCE 6) kept for backward compatibility.
+	fakeHandle.device_number = -1; // start of iteration
+	return MockMidi::getInstance()->getNumDevices();
 }
 
-int snd_seq_query_next_client(snd_seq_t *handle, snd_seq_client_info_t *info)
-{
-    fakeHandle.device_number++;
-    fakeHandle.device_port_number = -1;
-    return (fakeHandle.device_number < MockMidi::getInstance()->getNumDevices() ? 0 : 1);
+int snd_seq_query_next_client(snd_seq_t *handle, snd_seq_client_info_t *info) {
+	fakeHandle.device_number++;
+	fakeHandle.device_port_number = -1;
+	return (fakeHandle.device_number < MockMidi::getInstance()->getNumDevices() ? 0 : 1);
 }
 
-int snd_seq_client_info_get_num_ports(const snd_seq_client_info_t *info)
-{
-    fakeHandle.device_port_number = -1;
-    if (0 <= fakeHandle.device_number && fakeHandle.device_number < MockMidi::getInstance()->getNumDevices())
-        return MockMidi::getInstance()->getNumPorts(fakeHandle.device_number);
-    return 0;
+int snd_seq_client_info_get_num_ports(const snd_seq_client_info_t *info) {
+	fakeHandle.device_port_number = -1;
+	if (0 <= fakeHandle.device_number && fakeHandle.device_number < MockMidi::getInstance()->getNumDevices())
+		return MockMidi::getInstance()->getNumPorts(fakeHandle.device_number);
+	return 0;
 }
 
-int snd_seq_client_info_get_client(const snd_seq_client_info_t *info)
-{
-    return fakeHandle.device_number;
+int snd_seq_client_info_get_client(const snd_seq_client_info_t *info) {
+	return fakeHandle.device_number;
 }
 
 // for iterating over ports of devices
-int snd_seq_query_next_port(snd_seq_t *handle, snd_seq_port_info_t *info)
-{
-    fakeHandle.device_port_number++;
-    return (fakeHandle.device_port_number < MockMidi::getInstance()->getNumPorts(fakeHandle.device_number) ? 0 : 1);
+int snd_seq_query_next_port(snd_seq_t *handle, snd_seq_port_info_t *info) {
+	fakeHandle.device_port_number++;
+	return (fakeHandle.device_port_number < MockMidi::getInstance()->getNumPorts(fakeHandle.device_number) ? 0 : 1);
 }
-unsigned int snd_seq_port_info_get_capability(const snd_seq_port_info_t *info)
-{
-    // all ports can read/write in this fake
-    return SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_SUBS_WRITE;
+unsigned int snd_seq_port_info_get_capability(const snd_seq_port_info_t *info) {
+	// all ports can read/write in this fake
+	return SND_SEQ_PORT_CAP_SUBS_READ | SND_SEQ_PORT_CAP_SUBS_WRITE;
 }
 
 // These are present in modern libasound and JUCE reads them from the port/client info structs
 // during enumeration. We don't populate those (opaque) structs, so define the getters to return
 // deterministic, legacy-MIDI values: every mock port is a bidirectional MIDI 1.0 (non-UMP) port.
-int snd_seq_port_info_get_direction(const snd_seq_port_info_t *info) { return SND_SEQ_PORT_DIR_BIDIRECTION; }
-int snd_seq_port_info_get_ump_group(const snd_seq_port_info_t *info) { return 0; }
-int snd_seq_client_info_get_midi_version(const snd_seq_client_info_t *info) { return SND_SEQ_CLIENT_LEGACY_MIDI; }
-
-const char *snd_seq_port_info_get_name(const snd_seq_port_info_t *info)
-{
-    static char buffer[32];
-    if (0 <= fakeHandle.device_number && fakeHandle.device_number < MockMidi::getInstance()->getNumDevices() &&
-        0 <= fakeHandle.device_port_number && fakeHandle.device_port_number < MockMidi::getInstance()->getNumPorts(fakeHandle.device_number))
-        snprintf(buffer, sizeof(buffer), "Device %02d, port %02d", fakeHandle.device_number, fakeHandle.device_port_number);
-    else
-        snprintf(buffer, sizeof(buffer), "??? %02d, %02d ???", fakeHandle.device_number, fakeHandle.device_port_number);
-    return buffer;
+int snd_seq_port_info_get_direction(const snd_seq_port_info_t *info) {
+	return SND_SEQ_PORT_DIR_BIDIRECTION;
+}
+int snd_seq_port_info_get_ump_group(const snd_seq_port_info_t *info) {
+	return 0;
+}
+int snd_seq_client_info_get_midi_version(const snd_seq_client_info_t *info) {
+	return SND_SEQ_CLIENT_LEGACY_MIDI;
 }
 
-int snd_seq_port_info_get_port(const snd_seq_port_info_t *info)
-{
-    return fakeHandle.device_port_number;
+const char *snd_seq_port_info_get_name(const snd_seq_port_info_t *info) {
+	static char buffer[32];
+	if (0 <= fakeHandle.device_number && fakeHandle.device_number < MockMidi::getInstance()->getNumDevices() &&
+		0 <= fakeHandle.device_port_number &&
+		fakeHandle.device_port_number < MockMidi::getInstance()->getNumPorts(fakeHandle.device_number))
+		snprintf(buffer, sizeof(buffer), "Device %02d, port %02d", fakeHandle.device_number,
+				 fakeHandle.device_port_number);
+	else
+		snprintf(buffer, sizeof(buffer), "??? %02d, %02d ???", fakeHandle.device_number, fakeHandle.device_port_number);
+	return buffer;
+}
+
+int snd_seq_port_info_get_port(const snd_seq_port_info_t *info) {
+	return fakeHandle.device_port_number;
 }
 
 /**************************************************************
@@ -469,62 +455,63 @@ int snd_seq_port_info_get_port(const snd_seq_port_info_t *info)
 // JUCE 8 connects to real devices via snd_seq_subscribe_port. The subscription carries the
 // 'sender' and 'dest' addresses (filled by the real libasound setters into a real, stack-allocated
 // snd_seq_port_subscribe_t), which we read back via the real getters.
-int snd_seq_subscribe_port(snd_seq_t *seq, snd_seq_port_subscribe_t *sub)
-{
-    const snd_seq_addr_t *sender = snd_seq_port_subscribe_get_sender(sub);
-    const snd_seq_addr_t *dest = snd_seq_port_subscribe_get_dest(sub);
-    if (sender == nullptr || dest == nullptr)
-        return 0;
+int snd_seq_subscribe_port(snd_seq_t *seq, snd_seq_port_subscribe_t *sub) {
+	const snd_seq_addr_t *sender = snd_seq_port_subscribe_get_sender(sub);
+	const snd_seq_addr_t *dest = snd_seq_port_subscribe_get_dest(sub);
+	if (sender == nullptr || dest == nullptr)
+		return 0;
 
-    const int myClient = FakeSndSeqState::applicationClientId;
+	const int myClient = FakeSndSeqState::applicationClientId;
 
-    if (dest->client != myClient)
-    {
-        // dest is the device -> this is an OUTPUT (host -> device); sender is our application port.
-        fakeHandle.application_to_device_port_map[sender->port] = std::make_tuple(dest->client, dest->port);
-        MockMidi::getInstance()->openOutput(dest->client, dest->port);
-    }
-    else if (sender->client != myClient)
-    {
-        // sender is the device -> this is an INPUT (device -> host); dest is our application port.
-        fakeHandle.inputAppPort = dest->port;
-        fakeHandle.application_to_device_port_map[dest->port] = std::make_tuple(sender->client, sender->port);
-        MockMidi::getInstance()->openInput(sender->client, sender->port);
-    }
-    return 0;
+	if (dest->client != myClient) {
+		// dest is the device -> this is an OUTPUT (host -> device); sender is our application port.
+		fakeHandle.application_to_device_port_map[sender->port] = std::make_tuple(dest->client, dest->port);
+		MockMidi::getInstance()->openOutput(dest->client, dest->port);
+	} else if (sender->client != myClient) {
+		// sender is the device -> this is an INPUT (device -> host); dest is our application port.
+		fakeHandle.inputAppPort = dest->port;
+		fakeHandle.application_to_device_port_map[dest->port] = std::make_tuple(sender->client, sender->port);
+		MockMidi::getInstance()->openInput(sender->client, sender->port);
+	}
+	return 0;
 }
-int snd_seq_unsubscribe_port(snd_seq_t *seq, snd_seq_port_subscribe_t *sub) { return 0; }
+int snd_seq_unsubscribe_port(snd_seq_t *seq, snd_seq_port_subscribe_t *sub) {
+	return 0;
+}
 
 // from seqmid.h
-int snd_seq_connect_from(snd_seq_t *seq, int my_port, int src_client, int src_port)
-{
-    // JUCE 8 subscribes the system 'announce' port (client 0, port 1) this way; ignore only that.
-    // NB: don't guard on src_client alone -- JUCE 6's MidiInput::openDevice subscribes real device
-    // input through snd_seq_connect_from, and the mock enumerates its (only) device as client 0,
-    // which would otherwise collide with SND_SEQ_CLIENT_SYSTEM and never open the input.
-    if (src_client == SND_SEQ_CLIENT_SYSTEM && src_port == SND_SEQ_PORT_SYSTEM_ANNOUNCE)
-        return 0;
+int snd_seq_connect_from(snd_seq_t *seq, int my_port, int src_client, int src_port) {
+	// JUCE 8 subscribes the system 'announce' port (client 0, port 1) this way; ignore only that.
+	// NB: don't guard on src_client alone -- JUCE 6's MidiInput::openDevice subscribes real device
+	// input through snd_seq_connect_from, and the mock enumerates its (only) device as client 0,
+	// which would otherwise collide with SND_SEQ_CLIENT_SYSTEM and never open the input.
+	if (src_client == SND_SEQ_CLIENT_SYSTEM && src_port == SND_SEQ_PORT_SYSTEM_ANNOUNCE)
+		return 0;
 
-    // (Legacy / JUCE 6) the 'src' is the input device.
-    fakeHandle.inputAppPort = (unsigned char) my_port;
-    fakeHandle.application_to_device_port_map[my_port] = std::make_tuple(src_client, src_port);
-    MockMidi::getInstance()->openInput(src_client, src_port);
-    return 0;
+	// (Legacy / JUCE 6) the 'src' is the input device.
+	fakeHandle.inputAppPort = (unsigned char)my_port;
+	fakeHandle.application_to_device_port_map[my_port] = std::make_tuple(src_client, src_port);
+	MockMidi::getInstance()->openInput(src_client, src_port);
+	return 0;
 }
-int snd_seq_connect_to(snd_seq_t *seq, int my_port, int dest_client, int dest_port)
-{
-    // (Legacy / JUCE 6) the 'dest' is the output device.
-    fakeHandle.application_to_device_port_map[my_port] = std::make_tuple(dest_client, dest_port);
-    MockMidi::getInstance()->openOutput(dest_client, dest_port);
-    return 0;
+int snd_seq_connect_to(snd_seq_t *seq, int my_port, int dest_client, int dest_port) {
+	// (Legacy / JUCE 6) the 'dest' is the output device.
+	fakeHandle.application_to_device_port_map[my_port] = std::make_tuple(dest_client, dest_port);
+	MockMidi::getInstance()->openOutput(dest_client, dest_port);
+	return 0;
 }
-int snd_seq_disconnect_from(snd_seq_t *seq, int my_port, int src_client, int src_port) { return 0; }
-int snd_seq_disconnect_to(snd_seq_t *seq, int my_port, int dest_client, int dest_port) { return 0; }
+int snd_seq_disconnect_from(snd_seq_t *seq, int my_port, int src_client, int src_port) {
+	return 0;
+}
+int snd_seq_disconnect_to(snd_seq_t *seq, int my_port, int dest_client, int dest_port) {
+	return 0;
+}
 
-int snd_seq_create_simple_port(snd_seq_t *seq, const char *name, unsigned int caps, unsigned int type)
-{
-    return fakeHandle.application_port_number++;
+int snd_seq_create_simple_port(snd_seq_t *seq, const char *name, unsigned int caps, unsigned int type) {
+	return fakeHandle.application_port_number++;
 }
-int snd_seq_delete_simple_port(snd_seq_t *seq, int port) { return 0; }
+int snd_seq_delete_simple_port(snd_seq_t *seq, int port) {
+	return 0;
+}
 
 #endif

--- a/Tests/mock_MidiDeviceCoreMidi.cpp
+++ b/Tests/mock_MidiDeviceCoreMidi.cpp
@@ -9,13 +9,35 @@
 #endif
 
 #include "mock_MidiDevice.h"
+// This mock shadows the MIDIEventList / protocol-aware CoreMIDI API
+// (MIDIInputPortCreateWithProtocol, MIDISendEventList, ...) and leans on JUCE's
+// universal_midi_packets converters. It supports JUCE 6 and JUCE 8 from one source, so that the
+// file can be merged between those branches without being rewritten each time.
+//
+// Both JUCE versions take the same road at runtime: juce_mac_CoreMidi.mm / juce_CoreMidi_mac.mm
+// select the EventList/UMP API under `if (@available (macOS 11, iOS 14, *))` and only fall back to
+// the older MIDIPacketList API below macOS 11. Every CI runner is well above that, so the
+// MIDIPacketList path is left to the framework (referenced but never called) on both versions and
+// there is nothing version-specific about the CoreMIDI surface itself.
+//
+// What does differ is JUCE's UMP layer -- see the three JUCE_MAJOR_VERSION guards below:
+//   1. header location and visibility (here)
+//   2. GenericUMPConverter::convert's input type (deliverToBlocks)
+//   3. the ToBytestreamConverter callback signature (MIDISendEventList)
 #if JUCE_MAC
 
 InformMockMidiOfSubsystem mockMidiSubsystem;
 
-// JUCE's universal_midi_packets headers are included only inside juce_audio_devices.cpp, so they
-// are not visible through <JuceHeader.h>. Pull the (header-only) converter chain in directly; the
-// few out-of-line symbols (View::size, SysEx7 helpers) link from the already-compiled JUCE module.
+#if JUCE_MAJOR_VERSION >= 8
+// JUCE 8 exposes the converter chain publicly: juce_audio_basics.h includes midi/ump/juce_UMP.h and
+// declares `namespace juce { namespace ump = universal_midi_packets; }`, so <JuceHeader.h> (pulled
+// in by mock_MidiDevice.h above) is all this file needs. As of 8.0.12 these headers live in
+// juce_audio_basics/midi/ump/, and the old juce_audio_devices/midi_io/ump/ directory holds
+// unrelated files (juce_UMPEndpoint.h, juce_UMPSession.h, ...).
+#else
+// JUCE 6 keeps the chain private to the module -- juce_audio_devices.h does not include it and the
+// `ump` alias exists only inside juce_audio_devices.cpp -- so include it by hand, in dependency
+// order, exactly as juce_audio_devices.cpp does.
 #include <juce_audio_devices/midi_io/ump/juce_UMPProtocols.h>
 #include <juce_audio_devices/midi_io/ump/juce_UMPUtils.h>
 #include <juce_audio_devices/midi_io/ump/juce_UMPacket.h>
@@ -28,6 +50,7 @@ InformMockMidiOfSubsystem mockMidiSubsystem;
 #include <juce_audio_devices/midi_io/ump/juce_UMPMidi1ToBytestreamTranslator.h>
 #include <juce_audio_devices/midi_io/ump/juce_UMPMidi1ToMidi2DefaultTranslator.h>
 #include <juce_audio_devices/midi_io/ump/juce_UMPConverters.h>
+#endif
 
 #include <algorithm>
 #include <cstdio>
@@ -138,11 +161,25 @@ namespace
         MIDIEventPacket* packet = MIDIEventListInit (list, kMIDIProtocol_1_0);
 
         ump::GenericUMPConverter converter (ump::PacketProtocol::MIDI_1_0);
-        converter.convert (msg, [&] (const ump::View& view)
+
+        // GUARD 2: as of JUCE 8.0.12 convert() takes a BytesOnGroup, View, Packets or an iterator
+        // pair -- the MidiMessage overload JUCE 6 has was removed. Either way the callback receives
+        // a View per converted packet, so only the input differs.
+        const auto emitPacket = [&] (const ump::View& view)
         {
             packet = MIDIEventListAdd (list, sizeof (storage), packet, /*timeStamp*/ 0,
                                        view.size(), view.data());
-        });
+        };
+
+#if JUCE_MAJOR_VERSION >= 8
+        converter.convert (ump::BytesOnGroup { 0,
+                               juce::Span<const std::byte> (
+                                   reinterpret_cast<const std::byte*> (msg.getRawData()),
+                                   (size_t) msg.getRawDataSize()) },
+                           emitPacket);
+#else
+        converter.convert (msg, emitPacket);
+#endif
 
         for (auto block : blocks)
             if (block != nullptr)
@@ -326,10 +363,26 @@ OSStatus MIDISendEventList (MIDIPortRef, MIDIEndpointRef dest, const MIDIEventLi
         ump::Iterator it   (packet->words, packet->wordCount * sizeof (juce::uint32));
         ump::Iterator end  (packet->words + packet->wordCount, 0);
         for (; it != end; ++it)
+            // GUARD 3: JUCE 6's translator hands the callback a ready-made MidiMessage. As of JUCE
+            // 8.0.12 SingleGroupMidi1ToBytestreamTranslator::dispatch instead calls
+            // `callback (BytesOnGroup { 0, bytes }, time)`, so the message must be rebuilt from the
+            // bytes. The body is the same either way.
+#if JUCE_MAJOR_VERSION >= 8
+            converter.convert (*it, 0.0, [&] (const ump::BytesOnGroup& groupBytes, double)
+            {
+                if (groupBytes.bytes.empty())
+                    return;
+
+                m->sendMidiEvent (dev, port,
+                                  juce::MidiMessage (groupBytes.bytes.data(),
+                                                     (int) groupBytes.bytes.size()));
+            });
+#else
             converter.convert (*it, 0.0, [&] (const juce::MidiMessage& msg)
             {
                 m->sendMidiEvent (dev, port, msg);
             });
+#endif
 
         packet = MIDIEventPacketNext (packet);
     }

--- a/Tests/test_ProcessorMidiRouting.cpp
+++ b/Tests/test_ProcessorMidiRouting.cpp
@@ -1,8 +1,8 @@
 #include "test_ProcessorFixture.h"
 
 #include "CtrlrManager.h"
-#include "CtrlrPanel.h"
 #include "CtrlrModulator.h"
+#include "CtrlrPanel.h"
 
 #include <chrono>
 #include <mutex>
@@ -20,7 +20,7 @@
  * Most are characterization tests (locking down behavior we believe correct). A small number are
  * *specification* tests asserting the DESIRED behavior for the suspected duplicate-output bug
  * (see CtrlrProcessor.cpp:179 unconditional echo + CtrlrPanel::sendMidi host fan-out).
- * 
+ *
  * Accepted failures are listed in Tests/known_failures.txt.
  *
  * Seam: black-box only. We drive processBlock / setParameter / the mock's injectMidiInput, and
@@ -33,45 +33,41 @@ using ::testing::Invoke;
 
 // Shared helpers (allowAndRecordDeviceSends / countDeviceSends / loadPanel / runHostBlocks /
 // pumpInputThreads) and count_equal now live in test_ProcessorFixture.h.
-class MidiRouting : public ProcessorInstance
-{
-};
+class MidiRouting : public ProcessorInstance {};
 
 /**
  * H2H, single panel: one host CC must reach the host output exactly once.
  * SPEC: desired once-ness in the face of the unconditional echo at CtrlrProcessor.cpp:179.
  * A CC that does NOT match the panel modulator is used so only the thru/echo path is exercised.
  */
-TEST_F(MidiRouting, h2h_single_panel_host_cc_reaches_host_once)
-{
-    allowAndRecordDeviceSends();
-    ASSERT_NE(loadPanel("fixture_host2host_cc.panel"), nullptr);
+TEST_F(MidiRouting, h2h_single_panel_host_cc_reaches_host_once) {
+	allowAndRecordDeviceSends();
+	ASSERT_NE(loadPanel("fixture_host2host_cc.panel"), nullptr);
 
-    const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
-    juce::MidiBuffer in;
-    in.addEvent(cc, 0);
+	const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
+	juce::MidiBuffer in;
+	in.addEvent(cc, 0);
 
-    auto host = runHostBlocks(in);
-    EXPECT_EQ(count_equal(host, cc), 1) << "host CC should be forwarded to host exactly once";
+	auto host = runHostBlocks(in);
+	EXPECT_EQ(count_equal(host, cc), 1) << "host CC should be forwarded to host exactly once";
 }
 
 /**
  * H2H, two panels both with H2H + outputToHost: one host CC must reach the host ONCE, not
  * once-per-panel. SPEC.
  */
-TEST_F(MidiRouting, h2h_multi_panel_host_cc_reaches_host_once)
-{
-    allowAndRecordDeviceSends();
-    ASSERT_NE(loadPanel("fixture_host2host_cc.panel"), nullptr);
-    ASSERT_NE(loadPanel("fixture_host2host_cc.panel"), nullptr);
-    ASSERT_EQ(processor->getManager().getNumPanels(), 2);
+TEST_F(MidiRouting, h2h_multi_panel_host_cc_reaches_host_once) {
+	allowAndRecordDeviceSends();
+	ASSERT_NE(loadPanel("fixture_host2host_cc.panel"), nullptr);
+	ASSERT_NE(loadPanel("fixture_host2host_cc.panel"), nullptr);
+	ASSERT_EQ(processor->getManager().getNumPanels(), 2);
 
-    const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
-    juce::MidiBuffer in;
-    in.addEvent(cc, 0);
+	const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
+	juce::MidiBuffer in;
+	in.addEvent(cc, 0);
 
-    auto host = runHostBlocks(in);
-    EXPECT_EQ(count_equal(host, cc), 1) << "host CC must reach host once, not once-per-panel";
+	auto host = runHostBlocks(in);
+	EXPECT_EQ(count_equal(host, cc), 1) << "host CC must reach host once, not once-per-panel";
 }
 
 /**
@@ -80,106 +76,114 @@ TEST_F(MidiRouting, h2h_multi_panel_host_cc_reaches_host_once)
  * exactly one (the H2H thru), while today the unconditional echo + sendMidi's host fan-out produce
  * a duplicate. SPEC (matches the already-known-failing Host2Device case).
  */
-TEST_F(MidiRouting, h2d_host_cc_reaches_device_once_and_host_once)
-{
-    allowAndRecordDeviceSends();
-    ASSERT_NE(loadPanel("fixture_host2device_cc.panel"), nullptr);
+TEST_F(MidiRouting, h2d_host_cc_reaches_device_once_and_host_once) {
+	allowAndRecordDeviceSends();
+	ASSERT_NE(loadPanel("fixture_host2device_cc.panel"), nullptr);
 
-    const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
-    juce::MidiBuffer in;
-    in.addEvent(cc, 0);
+	const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
+	juce::MidiBuffer in;
+	in.addEvent(cc, 0);
 
-    auto host = runHostBlocks(in);
+	auto host = runHostBlocks(in);
 
-    EXPECT_EQ(countDeviceSends(cc), 1) << "H2D should send the host CC to the device once";
-    EXPECT_EQ(count_equal(host, cc), 1) << "host CC must not be duplicated on the host output";
+	EXPECT_EQ(countDeviceSends(cc), 1) << "H2D should send the host CC to the device once";
+	EXPECT_EQ(count_equal(host, cc), 1) << "host CC must not be duplicated on the host output";
 }
 
 /**
  * D2H thru: a CC injected from the device is forwarded to the host output exactly once.
  * Uses a non-matching CC so only the D2H thru path is exercised (no modulator send). Characterization.
+ *
+ * TIMING (do not "simplify" the loop below into pump-then-drain):
+ * This works around a MIDI handling bug that will be addressed later.
+ * CtrlrProcessor::addMidiToOutputQueue stamps queued messages with their sample position (1 or 2),
+ * which juce::MidiMessageCollector reads as *seconds* and compares against
+ * Time::getMillisecondCounterHiRes() * 0.001 -- so they sit at a hugely negative sample position.
+ * Whenever the gap between two removeNextBlockOfMessages() calls exceeds (numSamples << 5) samples
+ * (743ms at 44.1kHz / 1024), the collector sets startSample > 0, skips past every such message via
+ * findNextSamplePosition(), and then clear()s the queue -- destroying them permanently.
+ *
+ * Interleaving processBlock with the pump keeps every gap at ~25ms, far below the threshold.
+ * Production code is left as-is deliberately.
  */
-TEST_F(MidiRouting, d2h_injected_cc_reaches_host_once)
-{
-    if (!midi_mock.hasSubsystemMock())
-        GTEST_SKIP() << "no MIDI subsystem mock on this platform; device input cannot be injected";
+TEST_F(MidiRouting, d2h_injected_cc_reaches_host_once) {
+	if (!midi_mock.hasSubsystemMock())
+		GTEST_SKIP() << "no MIDI subsystem mock on this platform; device input cannot be injected";
 
-    allowAndRecordDeviceSends();
-    CtrlrPanel* panel = loadPanel("fixture_device_input_cc.panel");
-    ASSERT_NE(panel, nullptr);
-    processor->prepareToPlay(44100, BLOCK_SIZE);
+	allowAndRecordDeviceSends();
+	CtrlrPanel *panel = loadPanel("fixture_device_input_cc.panel");
+	ASSERT_NE(panel, nullptr);
+	processor->prepareToPlay(44100, BLOCK_SIZE);
 
-    const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
-    MockMidi::getInstance()->injectMidiInput(cc);
-    pumpInputThreads();
+	const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
+	MockMidi::getInstance()->injectMidiInput(cc);
 
-    // Drain host output across a few blocks (the D2H thru goes through the MidiMessageCollector).
-    std::vector<juce::MidiMessage> host;
-    for (int i = 0; i < 5; i++)
-    {
-        midiMessages.clear();
-        std::this_thread::sleep_for(std::chrono::milliseconds(23));
-        processor->processBlock(buffer, midiMessages);
-        for (const auto meta : midiMessages)
-            host.push_back(meta.getMessage());
-    }
+	// Pump the message loop and drain host output in the same loop, so no two processBlock calls
+	// are more than ~25ms apart. ~1.2s total covers the panel input thread's 500ms process() tick
+	// (the D2H thru is queued from that thread, not from processBlock).
+	std::vector<juce::MidiMessage> host;
+	for (int i = 0; i < 48; i++) {
+		juce::MessageManager::getInstance()->runDispatchLoopUntil(25);
 
-    EXPECT_EQ(count_equal(host, cc), 1) << "device-injected CC should reach host once via D2H";
+		midiMessages.clear();
+		processor->processBlock(buffer, midiMessages);
+		for (const auto meta : midiMessages)
+			host.push_back(meta.getMessage());
+	}
+
+	EXPECT_EQ(count_equal(host, cc), 1) << "device-injected CC should reach host once via D2H";
 }
 
 /**
  * Device input that matches a modulator's comparator updates that modulator's parameter.
  * Characterization of the input-compare path on the device side.
  */
-TEST_F(MidiRouting, device_input_matching_cc_updates_modulator)
-{
-    if (!midi_mock.hasSubsystemMock())
-        GTEST_SKIP() << "no MIDI subsystem mock on this platform; device input cannot be injected";
+TEST_F(MidiRouting, device_input_matching_cc_updates_modulator) {
+	if (!midi_mock.hasSubsystemMock())
+		GTEST_SKIP() << "no MIDI subsystem mock on this platform; device input cannot be injected";
 
-    allowAndRecordDeviceSends();
-    CtrlrPanel* panel = loadPanel("fixture_device_input_cc.panel");
-    ASSERT_NE(panel, nullptr);
-    processor->prepareToPlay(44100, BLOCK_SIZE);
+	allowAndRecordDeviceSends();
+	CtrlrPanel *panel = loadPanel("fixture_device_input_cc.panel");
+	ASSERT_NE(panel, nullptr);
+	processor->prepareToPlay(44100, BLOCK_SIZE);
 
-    // Matching CC: channel 4 (panelMidiOutputChannelDevice), controller 3 (midiMessageCtrlrNumber).
-    EXPECT_GT(openInputCalls, 0) << "panel should have opened the input device on load";
+	// Matching CC: channel 4 (panelMidiOutputChannelDevice), controller 3 (midiMessageCtrlrNumber).
+	EXPECT_GT(openInputCalls, 0) << "panel should have opened the input device on load";
 
-    const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(4, 3, 100);
-    MockMidi::getInstance()->injectMidiInput(cc);
-    pumpInputThreads();
-    // let any posted change messages settle:
-    for (int i = 0; i < 4; i++)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(23));
-        processor->processBlock(buffer, midiMessages);
-        midiMessages.clear();
-    }
+	const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(4, 3, 100);
+	MockMidi::getInstance()->injectMidiInput(cc);
+	pumpInputThreads();
+	// let any posted change messages settle:
+	for (int i = 0; i < 4; i++) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(23));
+		processor->processBlock(buffer, midiMessages);
+		midiMessages.clear();
+	}
 
-    EXPECT_FLOAT_EQ(processor->getParameter(1), 100.0f / 127.0f)
-        << "modulator parameter should track the matched device CC value";
+	EXPECT_FLOAT_EQ(processor->getParameter(1), 100.0f / 127.0f)
+		<< "modulator parameter should track the matched device CC value";
 }
 
 /**
  * Pause-out gating: with panelMidiPauseOut set, a parameter change produces NO device send.
  * Deterministic, no timing involved. Characterization.
  */
-TEST_F(MidiRouting, pause_out_blocks_device_send_on_value_change)
-{
-    // Allow device open (happens during load), but set NO sendMidiEvent expectation: with the
-    // StrictMock, any device send while paused-out fails the test. Expectations must be in place
-    // before loadPanel(), which opens the output device.
-    if (midi_mock.hasSubsystemMock())
-        EXPECT_CALL(midi_mock, openOutput(_, _)).Times(AnyNumber());
+TEST_F(MidiRouting, pause_out_blocks_device_send_on_value_change) {
+	// Allow device open (happens during load), but set NO sendMidiEvent expectation: with the
+	// StrictMock, any device send while paused-out fails the test. Expectations must be in place
+	// before loadPanel(), which opens the output device.
+	if (midi_mock.hasSubsystemMock())
+		EXPECT_CALL(midi_mock, openOutput(_, _)).Times(AnyNumber());
 
-    CtrlrPanel* panel = loadPanel("fixture_host2host_cc.panel");
-    ASSERT_NE(panel, nullptr);
+	CtrlrPanel *panel = loadPanel("fixture_host2host_cc.panel");
+	ASSERT_NE(panel, nullptr);
 
-    panel->setProperty(Ids::panelMidiPauseOut, true, false);
-    ASSERT_TRUE(panel->isMidiOutPaused());
+	panel->setProperty(Ids::panelMidiPauseOut, true, false);
+	ASSERT_TRUE(panel->isMidiOutPaused());
 
-    processor->prepareToPlay(44100, BLOCK_SIZE);
-    processor->setParameter(1, 0.5);
-    processor->processBlock(buffer, midiMessages);
+	processor->prepareToPlay(44100, BLOCK_SIZE);
+	processor->setParameter(1, 0.5);
+	processor->processBlock(buffer, midiMessages);
 }
 
 /**
@@ -189,21 +193,20 @@ TEST_F(MidiRouting, pause_out_blocks_device_send_on_value_change)
  * Note: the unconditional echo at CtrlrProcessor.cpp:179 is NOT gated by pause-in, so today the
  * host CC may still appear. This asserts the DESIRED gating; allowlisted if it fails. SPEC.
  */
-TEST_F(MidiRouting, pause_in_blocks_host_echo)
-{
-    allowAndRecordDeviceSends();
-    CtrlrPanel* panel = loadPanel("fixture_host2host_cc.panel");
-    ASSERT_NE(panel, nullptr);
+TEST_F(MidiRouting, pause_in_blocks_host_echo) {
+	allowAndRecordDeviceSends();
+	CtrlrPanel *panel = loadPanel("fixture_host2host_cc.panel");
+	ASSERT_NE(panel, nullptr);
 
-    panel->setProperty(Ids::panelMidiPauseIn, true, false);
-    ASSERT_TRUE(panel->isMidiInPaused());
+	panel->setProperty(Ids::panelMidiPauseIn, true, false);
+	ASSERT_TRUE(panel->isMidiInPaused());
 
-    const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100);
-    juce::MidiBuffer in;
-    in.addEvent(cc, 0);
+	const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100);
+	juce::MidiBuffer in;
+	in.addEvent(cc, 0);
 
-    auto host = runHostBlocks(in);
-    EXPECT_EQ(count_equal(host, cc), 0) << "paused-in panel should not echo host input back to host";
+	auto host = runHostBlocks(in);
+	EXPECT_EQ(count_equal(host, cc), 0) << "paused-in panel should not echo host input back to host";
 }
 
 /**
@@ -212,53 +215,50 @@ TEST_F(MidiRouting, pause_in_blocks_host_echo)
  * This fires outside processBlock (a ValueTree property change), so we wait for the async device
  * delivery and drain the host output afterwards. P1.
  */
-TEST_F(MidiRouting, program_change_fans_out_to_device_and_host_once)
-{
-    allowAndRecordDeviceSends();
-    CtrlrPanel* panel = loadPanel("fixture_program_change.panel");
-    ASSERT_NE(panel, nullptr);
-    processor->prepareToPlay(44100, BLOCK_SIZE);
+TEST_F(MidiRouting, program_change_fans_out_to_device_and_host_once) {
+	allowAndRecordDeviceSends();
+	CtrlrPanel *panel = loadPanel("fixture_program_change.panel");
+	ASSERT_NE(panel, nullptr);
+	processor->prepareToPlay(44100, BLOCK_SIZE);
 
-    // Channel 4 == panelMidiOutputChannelDevice; banks are 0 in the fixture.
-    const juce::MidiMessage pc = juce::MidiMessage::programChange(4, 7);
+	// Channel 4 == panelMidiOutputChannelDevice; banks are 0 in the fixture.
+	const juce::MidiMessage pc = juce::MidiMessage::programChange(4, 7);
 
-    panel->setProperty(Ids::panelMidiProgram, 7, false); // triggers sendMidiProgramChange()
+	panel->setProperty(Ids::panelMidiProgram, 7, false); // triggers sendMidiProgramChange()
 
-    // Drain host output (program change is queued to the host collector) and let the device's
-    // background thread flush.
-    std::vector<juce::MidiMessage> host;
-    for (int i = 0; i < 6; i++)
-    {
-        midiMessages.clear();
-        std::this_thread::sleep_for(std::chrono::milliseconds(23));
-        processor->processBlock(buffer, midiMessages);
-        for (const auto meta : midiMessages)
-            host.push_back(meta.getMessage());
-    }
+	// Drain host output (program change is queued to the host collector) and let the device's
+	// background thread flush.
+	std::vector<juce::MidiMessage> host;
+	for (int i = 0; i < 6; i++) {
+		midiMessages.clear();
+		std::this_thread::sleep_for(std::chrono::milliseconds(23));
+		processor->processBlock(buffer, midiMessages);
+		for (const auto meta : midiMessages)
+			host.push_back(meta.getMessage());
+	}
 
-    EXPECT_EQ(countDeviceSends(pc), 1) << "program change should reach the device exactly once";
-    EXPECT_EQ(count_equal(host, pc), 1) << "program change should reach the host exactly once";
+	EXPECT_EQ(countDeviceSends(pc), 1) << "program change should reach the device exactly once";
+	EXPECT_EQ(count_equal(host, pc), 1) << "program change should reach the host exactly once";
 }
 
 /**
  * D2D: a CC injected from the device is forwarded to the device output exactly once. Uses a
  * non-matching CC (so no modulator send) and toggles D2D on / D2H off in-test. P1.
  */
-TEST_F(MidiRouting, d2d_injected_cc_forwarded_to_device_once)
-{
-    if (!midi_mock.hasSubsystemMock())
-        GTEST_SKIP() << "no MIDI subsystem mock on this platform; device input cannot be injected";
+TEST_F(MidiRouting, d2d_injected_cc_forwarded_to_device_once) {
+	if (!midi_mock.hasSubsystemMock())
+		GTEST_SKIP() << "no MIDI subsystem mock on this platform; device input cannot be injected";
 
-    allowAndRecordDeviceSends();
-    CtrlrPanel* panel = loadPanel("fixture_device_input_cc.panel");
-    ASSERT_NE(panel, nullptr);
-    panel->setProperty(Ids::panelMidiThruD2D, true, false);
-    panel->setProperty(Ids::panelMidiThruD2H, false, false);
-    processor->prepareToPlay(44100, BLOCK_SIZE);
+	allowAndRecordDeviceSends();
+	CtrlrPanel *panel = loadPanel("fixture_device_input_cc.panel");
+	ASSERT_NE(panel, nullptr);
+	panel->setProperty(Ids::panelMidiThruD2D, true, false);
+	panel->setProperty(Ids::panelMidiThruD2H, false, false);
+	processor->prepareToPlay(44100, BLOCK_SIZE);
 
-    const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
-    MockMidi::getInstance()->injectMidiInput(cc);
-    pumpInputThreads();
+	const juce::MidiMessage cc = juce::MidiMessage::controllerEvent(1, 20, 100); // non-matching
+	MockMidi::getInstance()->injectMidiInput(cc);
+	pumpInputThreads();
 
-    EXPECT_EQ(countDeviceSends(cc), 1) << "D2D should forward the device CC to the device output once";
+	EXPECT_EQ(countDeviceSends(cc), 1) << "D2D should forward the device CC to the device output once";
 }


### PR DESCRIPTION
I've re-applied the memory fix as mentioned reverted in https://github.com/damiensellier/CtrlrX/pull/287#issuecomment-4996622068 , seems to compile well. Is the `5.6.36-Maintenance` branch the correct one? If not, let me know...

I've also update the test mocks and 1 test for compatibility with JUCE 8. This should allow a straight copy/paste into the 8.0.0 work (or a merge from that work into this branch).

Notes on formatting:
- the changed test-related files are reformatted (they were introduced before the clang-format I believe), so compare with ignoring whitespace
- the changed production files are reformatted in some places that I didn't expect, so maybe the clang-formatting file syntax is interpreted differently or so?